### PR TITLE
Remaining typos in template 88 (%PASS% instead of ensembl)

### DIFF
--- a/martbuilder_xml/v88_xml/ensembl_template_88.xml
+++ b/martbuilder_xml/v88_xml/ensembl_template_88.xml
@@ -3546,7 +3546,7 @@
 		<maskedColumn tableKey="translation__object_xref_1" colKey="1.18.0.db_release"/>
 		<renamedColumn tableKey="translation__object_xref_1" colKey="1.18.0.db_release" newName="db_release_1018"/>
 		<maskedColumn tableKey="translation__object_xref_1" colKey="1.40.0.ensembl_object_type"/>
-		<renamedColumn tableKey="translation__object_xref_1" colKey="1.40.0.ensembl_object_type" newName="%PASS%_object_type_1040"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
 		<maskedColumn tableKey="translation__object_xref_1" colKey="1.40.0.object_xref_id"/>
 		<renamedColumn tableKey="translation__object_xref_1" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040"/>
 		<renamedColumn tableKey="translation__object_xref_1" colKey="10.6.0.is_root" newName="is_root_1006"/>
@@ -3623,7 +3623,7 @@
 		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.18.0.db_release"/>
 		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.18.0.db_release" newName="db_release_1018"/>
 		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.40.0.ensembl_object_type"/>
-		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.40.0.ensembl_object_type" newName="%PASS%_object_type_1040"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
 		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.40.0.object_xref_id"/>
 		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040"/>
 		<renamedColumn tableKey="transcript__object_xref_1" colKey="10.6.0.is_root" newName="is_root_1006"/>
@@ -4054,7 +4054,7 @@
 		<maskedColumn tableKey="transcript__object_xref" colKey="1.18.0.secondary_db_table"/>
 		<renamedColumn tableKey="transcript__object_xref" colKey="1.18.0.secondary_db_table" newName="secondary_db_table_1018"/>
 		<maskedColumn tableKey="transcript__object_xref" colKey="1.40.0.ensembl_object_type"/>
-		<renamedColumn tableKey="transcript__object_xref" colKey="1.40.0.ensembl_object_type" newName="%PASS%_object_type_1040"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
 		<maskedColumn tableKey="transcript__object_xref" colKey="1.40.0.object_xref_id"/>
 		<renamedColumn tableKey="transcript__object_xref" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040"/>
 		<maskedColumn tableKey="transcript__object_xref" colKey="1.40.0.analysis_id"/>
@@ -4107,7 +4107,7 @@
 		<maskedColumn tableKey="gene__object_xref" colKey="1.18.0.secondary_db_table"/>
 		<renamedColumn tableKey="gene__object_xref" colKey="1.18.0.secondary_db_table" newName="secondary_db_table_1018"/>
 		<maskedColumn tableKey="gene__object_xref" colKey="1.40.0.ensembl_object_type"/>
-		<renamedColumn tableKey="gene__object_xref" colKey="1.40.0.ensembl_object_type" newName="%PASS%_object_type_1040"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
 		<maskedColumn tableKey="gene__object_xref" colKey="1.40.0.object_xref_id"/>
 		<renamedColumn tableKey="gene__object_xref" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040"/>
 		<maskedColumn tableKey="gene__object_xref" colKey="1.40.0.analysis_id"/>
@@ -4240,7 +4240,7 @@
 		<maskedColumn tableKey="translation__object_xref" colKey="1.18.0.secondary_db_table"/>
 		<renamedColumn tableKey="translation__object_xref" colKey="1.18.0.secondary_db_table" newName="secondary_db_table_1018"/>
 		<maskedColumn tableKey="translation__object_xref" colKey="1.40.0.ensembl_object_type"/>
-		<renamedColumn tableKey="translation__object_xref" colKey="1.40.0.ensembl_object_type" newName="%PASS%_object_type_1040"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
 		<maskedColumn tableKey="translation__object_xref" colKey="1.40.0.object_xref_id"/>
 		<renamedColumn tableKey="translation__object_xref" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040"/>
 		<maskedColumn tableKey="translation__object_xref" colKey="1.40.0.analysis_id"/>
@@ -4284,7 +4284,7 @@
 		<maskedColumn tableKey="gene__object_xref_1" colKey="1.18.0.db_release"/>
 		<renamedColumn tableKey="gene__object_xref_1" colKey="1.18.0.db_release" newName="db_release_1018"/>
 		<maskedColumn tableKey="gene__object_xref_1" colKey="1.40.0.ensembl_object_type"/>
-		<renamedColumn tableKey="gene__object_xref_1" colKey="1.40.0.ensembl_object_type" newName="%PASS%_object_type_1040"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
 		<maskedColumn tableKey="gene__object_xref_1" colKey="1.40.0.object_xref_id"/>
 		<renamedColumn tableKey="gene__object_xref_1" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040"/>
 		<renamedColumn tableKey="gene__object_xref_1" colKey="10.6.0.is_root" newName="is_root_1006"/>
@@ -4390,12 +4390,12 @@
 		<renamedColumn tableKey="object_xref" colKey="1.20.0.description" newName="description_1020"/>
 		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_release" newName="db_release_1018"/>
 		<renamedColumn tableKey="object_xref" colKey="1.20.0.created_date" newName="created_date_1020"/>
-		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_object_type" newName="%PASS%_object_type_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
 		<renamedColumn tableKey="object_xref" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040_key"/>
 		<renamedColumn tableKey="object_xref" colKey="1.18.0.secondary_db_name" newName="secondary_db_name_1018"/>
 		<renamedColumn tableKey="object_xref" colKey="1.20.0.stable_id" newName="stable_id_1020"/>
 		<renamedColumn tableKey="object_xref" colKey="1.20.0.analysis_id" newName="analysis_id_1020"/>
-		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_id" newName="%PASS%_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_id" newName="ensembl_id_1040"/>
 		<renamedColumn tableKey="object_xref" colKey="1.18.0.status" newName="status_1018"/>
 		<renamedColumn tableKey="object_xref" colKey="1.74.0.external_db_id" newName="external_db_id_1074"/>
 		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_name" newName="db_name_1018"/>
@@ -4483,12 +4483,12 @@
 		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_release" newName="db_release_1018"/>
 		<renamedColumn tableKey="object_xref" colKey="1.64.0.source" newName="source_1064"/>
 		<renamedColumn tableKey="object_xref" colKey="1.64.0.stable_id" newName="stable_id_1064"/>
-		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_object_type" newName="%PASS%_object_type_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
 		<renamedColumn tableKey="object_xref" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040_key"/>
 		<renamedColumn tableKey="object_xref" colKey="1.64.0.gene_id" newName="gene_id_1064"/>
 		<renamedColumn tableKey="object_xref" colKey="1.18.0.secondary_db_name" newName="secondary_db_name_1018"/>
 		<renamedColumn tableKey="object_xref" colKey="1.64.0.seq_region_end" newName="seq_region_end_1064"/>
-		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_id" newName="%PASS%_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_id" newName="ensembl_id_1040"/>
 		<renamedColumn tableKey="object_xref" colKey="1.64.0.version" newName="version_1064"/>
 		<renamedColumn tableKey="object_xref" colKey="1.18.0.status" newName="status_1018"/>
 		<renamedColumn tableKey="object_xref" colKey="1.74.0.external_db_id" newName="external_db_id_1074"/>
@@ -4570,12 +4570,12 @@
 		<renamedColumn tableKey="object_xref" colKey="1.40.0.xref_id" newName="xref_id_1040"/>
 		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_release" newName="db_release_1018"/>
 		<renamedColumn tableKey="object_xref" colKey="1.68.0.seq_start" newName="seq_start_1068"/>
-		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_object_type" newName="%PASS%_object_type_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
 		<renamedColumn tableKey="object_xref" colKey="1.68.0.start_exon_id" newName="start_exon_id_1068"/>
 		<renamedColumn tableKey="object_xref" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040_key"/>
 		<renamedColumn tableKey="object_xref" colKey="1.68.0.modified_date" newName="modified_date_1068"/>
 		<renamedColumn tableKey="object_xref" colKey="1.18.0.secondary_db_name" newName="secondary_db_name_1018"/>
-		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_id" newName="%PASS%_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_id" newName="ensembl_id_1040"/>
 		<renamedColumn tableKey="object_xref" colKey="1.18.0.status" newName="status_1018"/>
 		<renamedColumn tableKey="object_xref" colKey="1.74.0.external_db_id" newName="external_db_id_1074"/>
 		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_name" newName="db_name_1018"/>
@@ -4659,7 +4659,7 @@
 		<renamedColumn tableKey="object_xref" colKey="1.20.0.description" newName="description_1020"/>
 		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_release" newName="db_release_1018"/>
 		<renamedColumn tableKey="object_xref" colKey="1.20.0.created_date" newName="created_date_1020"/>
-		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_object_type" newName="%PASS%_object_type_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
 		<renamedColumn tableKey="object_xref" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040_key"/>
 		<renamedColumn tableKey="object_xref" colKey="10.6.0.is_root" newName="is_root_1006"/>
 		<renamedColumn tableKey="object_xref" colKey="10.6.0.subsets" newName="subsets_1006"/>
@@ -4668,7 +4668,7 @@
 		<renamedColumn tableKey="object_xref" colKey="1.20.0.stable_id" newName="stable_id_1020"/>
 		<renamedColumn tableKey="object_xref" colKey="1.20.0.analysis_id" newName="analysis_id_1020"/>
 		<renamedColumn tableKey="object_xref" colKey="10.6.0.term_id" newName="term_id_1006"/>
-		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_id" newName="%PASS%_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_id" newName="ensembl_id_1040"/>
 		<renamedColumn tableKey="object_xref" colKey="1.18.0.status" newName="status_1018"/>
 		<renamedColumn tableKey="object_xref" colKey="1.74.0.external_db_id" newName="external_db_id_1074"/>
 		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_name" newName="db_name_1018"/>
@@ -4754,10 +4754,10 @@
 		<renamedColumn tableKey="object_xref" colKey="1.40.0.xref_id" newName="xref_id_1040"/>
 		<renamedColumn tableKey="object_xref" colKey="1.64.0.source" newName="source_1064"/>
 		<renamedColumn tableKey="object_xref" colKey="1.64.0.stable_id" newName="stable_id_1064"/>
-		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_object_type" newName="%PASS%_object_type_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
 		<renamedColumn tableKey="object_xref" colKey="1.64.0.gene_id" newName="gene_id_1064"/>
 		<renamedColumn tableKey="object_xref" colKey="10.6.0.subsets" newName="subsets_1006"/>
-		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_id" newName="%PASS%_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_id" newName="ensembl_id_1040"/>
 		<renamedColumn tableKey="object_xref" colKey="1.18.0.status" newName="status_1018"/>
 		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_name" newName="db_name_1018"/>
 		<renamedColumn tableKey="object_xref" colKey="10.6.0.ontology_id" newName="ontology_id_1006"/>
@@ -4851,7 +4851,7 @@
 		<renamedColumn tableKey="object_xref" colKey="1.40.0.xref_id" newName="xref_id_1040"/>
 		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_release" newName="db_release_1018"/>
 		<renamedColumn tableKey="object_xref" colKey="1.68.0.seq_start" newName="seq_start_1068"/>
-		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_object_type" newName="%PASS%_object_type_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
 		<renamedColumn tableKey="object_xref" colKey="1.68.0.start_exon_id" newName="start_exon_id_1068"/>
 		<renamedColumn tableKey="object_xref" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040_key"/>
 		<renamedColumn tableKey="object_xref" colKey="1.68.0.modified_date" newName="modified_date_1068"/>
@@ -4860,7 +4860,7 @@
 		<renamedColumn tableKey="object_xref" colKey="10.6.0.is_obsolete" newName="is_obsolete_1006"/>
 		<renamedColumn tableKey="object_xref" colKey="1.18.0.secondary_db_name" newName="secondary_db_name_1018"/>
 		<renamedColumn tableKey="object_xref" colKey="10.6.0.term_id" newName="term_id_1006"/>
-		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_id" newName="%PASS%_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_id" newName="ensembl_id_1040"/>
 		<renamedColumn tableKey="object_xref" colKey="1.18.0.status" newName="status_1018"/>
 		<renamedColumn tableKey="object_xref" colKey="1.74.0.external_db_id" newName="external_db_id_1074"/>
 		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_name" newName="db_name_1018"/>


### PR DESCRIPTION
Leftover typos missed by 73f4d8405e7c65ea3126bcc7f4ef16e80b7681ee