### PR TITLE
Fix orthologs gene name link (wrong species used)

### DIFF
--- a/modules/Bio/EnsEMBL/BioMart/MetaBuilder.pm
+++ b/modules/Bio/EnsEMBL/BioMart/MetaBuilder.pm
@@ -1345,7 +1345,7 @@ sub write_attributes {
                   tableConstraint => $table }, {
                   displayName  => "$o_dataset->{display_name} gene name",
                   field        => "display_label_40273_r1",
-                  linkoutURL  => "exturl|/$dataset->{production_name}/Gene/Summary?g=%s|$o_dataset->{name}_homolog_ensembl_gene",
+                  linkoutURL  => "exturl|/$o_dataset->{production_name}/Gene/Summary?g=%s|$o_dataset->{name}_homolog_ensembl_gene",
                   internalName => "$o_dataset->{name}_homolog_associated_gene_name",
                   key          => "gene_id_1020_key",
                   maxLength    => "128",


### PR DESCRIPTION
When selecting an attribute "gene name" in the gene mart, the wrong species is used for the links.

This fix replaces the links like:
http://www.ensembl.org/homo_sapiens/Gene/Summary?g=ENSVPAG00000018133
to
http://www.ensembl.org/vicugna_pacos/Gene/Summary?g=ENSVPAG00000018133
(human gene mart vs orthologs in alpaca)