### PR TITLE
No need for 'wait_for' since it is already semaphored

### DIFF
--- a/modules/Bio/EnsEMBL/EGPipeline/PipeConfig/VariationMart_conf.pm
+++ b/modules/Bio/EnsEMBL/EGPipeline/PipeConfig/VariationMart_conf.pm
@@ -488,7 +488,6 @@ sub pipeline_analyses {
                             },
       -max_retry_count   => 0,
       -analysis_capacity => 10,
-      -wait_for          => ['CreateMartIndexes'],
       -can_be_empty      => 1,
       -flow_into         => ['AddSOMMetaData'],
       -rc_name           => 'normal',


### PR DESCRIPTION
This change also allows to regenerate the meta tables if no --division
or --species is given.