### PR TITLE
Replaced /tmp with /scratch, cleaned up where /tmp is not used

### DIFF
--- a/modules/Bio/EnsEMBL/BioMart/CreateMTMPProbestuffHelper.pm
+++ b/modules/Bio/EnsEMBL/BioMart/CreateMTMPProbestuffHelper.pm
@@ -25,14 +25,12 @@ use warnings;
 sub param_defaults {
   return {
     'drop_mtmp'         => 0,
-    'tmp_dir'           => '/tmp',
   };
 }
 
 sub run {
   my ($self) = @_;
   my $drop_mtmp = $self->param_required('drop_mtmp');
-  my $tmp_dir = $self->param_required('tmp_dir');
   my $dbc = $self->get_DBAdaptor('funcgen')->dbc();
   my $table='MTMP_probestuff_helper';
   my $species = $self->param_required('species');

--- a/modules/Bio/EnsEMBL/BioMart/CreateMTMPVariation.pm
+++ b/modules/Bio/EnsEMBL/BioMart/CreateMTMPVariation.pm
@@ -26,7 +26,6 @@ use base ('Bio::EnsEMBL::EGPipeline::VariationMart::Base');
 sub param_defaults {
   return {
     'drop_mtmp'         => 0,
-    'tmp_dir'           => '/tmp',
     'drop_mtmp_tv_vsv'   => 0,
   };
 }

--- a/modules/Bio/EnsEMBL/BioMart/MetaBuilder.pm
+++ b/modules/Bio/EnsEMBL/BioMart/MetaBuilder.pm
@@ -1019,10 +1019,10 @@ sub create_metatables {
   my $template_xml =
     XMLout( { DatasetConfig => $template->{config} }, KeepRoot => 1 );
 
-  if ( !-d "./tmp" ) {
-    mkdir "./tmp";
+  if ( !-d "./scratch" ) {
+    mkdir "./scratch";
   }
-  open my $out, ">", "./tmp/tmp.xml";
+  open my $out, ">", "./scratch/tmp.xml";
   print $out $template_xml;
   close $out;
   my $gzip_template;

--- a/modules/Bio/EnsEMBL/EGPipeline/PipeConfig/VariationMart_conf.pm
+++ b/modules/Bio/EnsEMBL/EGPipeline/PipeConfig/VariationMart_conf.pm
@@ -53,7 +53,7 @@ sub default_options {
     mtmp_tables_exist     => 0,
     always_skip_genotypes => [],
     never_skip_genotypes  => [],
-    tmp_dir               => '/tmp',
+    scratch_dir               => '/scratch',
     drop_mtmp             => 1,
     drop_mtmp_tv_vsv       => 0,
     snp_indep_tables      => [],
@@ -223,7 +223,7 @@ sub pipeline_create_commands {
     return [
       # inheriting database and hive tables' creation
       @{$self->SUPER::pipeline_create_commands},
-      'mkdir -p '.$self->o('tmp_dir'),
+      'mkdir -p '.$self->o('scratch_dir'),
     ];
 }
 
@@ -309,12 +309,12 @@ sub pipeline_analyses {
                               variation_feature_script => $self->o('variation_feature_script'),
                               variation_mtmp_script    => $self->o('variation_mtmp_script'),
                               registry                 => $self->o('registry'),
-                              tmp_dir                  => $self->o('tmp_dir'),
+                              scratch_dir                  => $self->o('scratch_dir'),
                             },
       -max_retry_count   => 3,
       -analysis_capacity => 5,
       -can_be_empty      => 1,
-      -rc_name           => '16Gb_mem_16Gb_tmp',
+      -rc_name           => '16Gb_mem_16Gb_scratch',
     },
 
     {
@@ -326,7 +326,7 @@ sub pipeline_analyses {
       -max_retry_count   => 0,
       -analysis_capacity => 5,
       -can_be_empty      => 1,
-      -rc_name           => '16Gb_mem_16Gb_tmp',
+      -rc_name           => '16Gb_mem_16Gb_scratch',
     },
 
     {
@@ -574,7 +574,7 @@ sub resource_classes {
     'default'           => {'LSF' => '-q production-rh7 -M  4000 -R "rusage[mem=4000]"'},
     'normal'            => {'LSF' => '-q production-rh7 -M  4000 -R "rusage[mem=4000]"'},
     '8Gb_mem'           => {'LSF' => '-q production-rh7 -M  8000 -R "rusage[mem=8000]"'},
-    '16Gb_mem_16Gb_tmp' => {'LSF' => '-q production-rh7 -M 16000 -R "rusage[mem=16000,tmp=16000]"'},
+    '16Gb_mem_16Gb_scratch' => {'LSF' => '-q production-rh7 -M 16000 -R "rusage[mem=16000,scratch=16000]"'},
   }
 }
 

--- a/modules/Bio/EnsEMBL/EGPipeline/VariationMart/CopyMart.pm
+++ b/modules/Bio/EnsEMBL/EGPipeline/VariationMart/CopyMart.pm
@@ -26,9 +26,7 @@ use base ('Bio::EnsEMBL::EGPipeline::VariationMart::Base');
 sub param_defaults {
   my ($self) = @_;
   
-  return {
-    'tmp_dir' => '/tmp',
-  };
+  return {};
 }
 
 sub fetch_input {

--- a/modules/Bio/EnsEMBL/EGPipeline/VariationMart/CreateMTMPTables.pm
+++ b/modules/Bio/EnsEMBL/EGPipeline/VariationMart/CreateMTMPTables.pm
@@ -32,7 +32,7 @@ sub param_defaults {
     'motif_exits'       => 1,
     'show_sams'         => 1,
     'show_pops'         => 1,
-    'tmp_dir'           => '/tmp',
+    'scratch_dir'           => '/scratch',
   };
 }
 
@@ -82,8 +82,8 @@ sub sample_genotype {
   
   my $drop_mtmp = $self->param_required('drop_mtmp');
   my $dbc = $self->get_DBAdaptor('variation')->dbc();
-  my $tmp_dir = $self->param_required('tmp_dir');
-  my $output_file = "$tmp_dir/mtmp_sg_".$self->param_required('species').".txt";
+  my $scratch_dir = $self->param_required('scratch_dir');
+  my $output_file = "$scratch_dir/mtmp_sg_".$self->param_required('species').".txt";
   
   my $hive_dbc = $self->dbc;
   $hive_dbc->disconnect_if_idle();

--- a/modules/Bio/EnsEMBL/EGPipeline/VariationMart/PopulateMart.pm
+++ b/modules/Bio/EnsEMBL/EGPipeline/VariationMart/PopulateMart.pm
@@ -26,7 +26,7 @@ use File::Spec::Functions qw(catdir);
 
 sub param_defaults {
   return {
-    'tmp_dir' => '/tmp',
+    'scratch_dir' => '/scratch',
   };
 }
 
@@ -35,7 +35,7 @@ sub run {
   
   my $table = $self->param_required('table');
   my $job_id = $self->input_job->dbID();
-  my $output_file = $self->param('tmp_dir')."/$table.$job_id.sql";
+  my $output_file = $self->param('scratch_dir')."/$table.$job_id.sql";
   
   $self->dump_data($table, $output_file);
   $self->load_data($table, $output_file);

--- a/modules/Bio/EnsEMBL/PipeConfig/BuildGeneMartMTMPTables_conf.pm
+++ b/modules/Bio/EnsEMBL/PipeConfig/BuildGeneMartMTMPTables_conf.pm
@@ -32,7 +32,7 @@ sub resource_classes {
   my ($self) = @_;
   return { 'default' => { 'LSF' => '-q production-rh7' },
            'normal'            => {'LSF' => '-q production-rh7 -M  4000 -R "rusage[mem=4000]"'},
-    '16Gb_mem_16Gb_tmp' => {'LSF' => '-q production-rh7 -M 16000 -R "rusage[mem=16000,tmp=16000]"'}
+    '16Gb_mem_16Gb_scratch' => {'LSF' => '-q production-rh7 -M 16000 -R "rusage[mem=16000,scratch=16000]"'}
     };
 }
 
@@ -55,7 +55,7 @@ sub default_options {
            'variation_feature_script' => $self->o('base_dir').'/ensembl-variation/scripts/misc/mart_variation_effect.pl',
            'variation_mtmp_script' => $self->o('base_dir').'/ensembl-variation/scripts/misc/create_MTMP_tables.pl',
            'mart_phenotypes_script' => $self->o('base_dir').'/ensembl-variation/scripts/misc/mart_phenotypes.pl',
-           'tmp_dir'                  => '/tmp',
+           'scratch_dir'                  => '/scratch',
   };
 }
 
@@ -124,7 +124,7 @@ sub pipeline_analyses {
       -max_retry_count   => 3,
       -analysis_capacity => 5,
       -can_be_empty      => 1,
-      -rc_name           => '16Gb_mem_16Gb_tmp',
+      -rc_name           => '16Gb_mem_16Gb_scratch',
     },
     {
       -logic_name        => 'CreateMTMPVariation',
@@ -136,13 +136,13 @@ sub pipeline_analyses {
                               variation_feature_script => $self->o('variation_feature_script'),
                               variation_mtmp_script    => $self->o('variation_mtmp_script'),
                               registry                 => $self->o('registry'),
-                              tmp_dir                  => $self->o('tmp_dir'),
+                              scratch_dir                  => $self->o('scratch_dir'),
                               mart_phenotypes_script   => $self->o('mart_phenotypes_script'),
                             },
       -max_retry_count   => 3,
       -analysis_capacity => 5,
       -can_be_empty      => 1,
-      -rc_name           => '16Gb_mem_16Gb_tmp',
+      -rc_name           => '16Gb_mem_16Gb_scratch',
     },
   ];
   return $analyses;


### PR DESCRIPTION
Use /scratch rather than /tmp space, as now recommended by TSC, for reasons of stability. This will hopefully fix the small numbers of intermittent and non-repeatable failures we get with every pipeline (https://www.ebi.ac.uk/panda/jira/browse/ENSPROD-2755)