### PR TITLE
Increased chr_name size to match core database seq_region table since…

### DIFF
--- a/modules/Bio/EnsEMBL/BioMart/BuildSequenceMart.pm
+++ b/modules/Bio/EnsEMBL/BioMart/BuildSequenceMart.pm
@@ -34,7 +34,7 @@ sub run {
     $mart_dbc->sql_helper()->execute_update(-SQL=>qq/create table $table
 (
 chunk_key int(10) not null,
-chr_name varchar(40) not null default '',
+chr_name varchar(255) not null default '',
 chr_start int(10) not null default '0',
 sequence mediumtext
 )ENGINE=MyISAM MAX_ROWS=100000 AVG_ROW_LENGTH=100000/

--- a/modules/Bio/EnsEMBL/PipeConfig/BuildMart_conf.pm
+++ b/modules/Bio/EnsEMBL/PipeConfig/BuildMart_conf.pm
@@ -329,7 +329,8 @@ sub pipeline_analyses {
                        'genomic_features_mart' => $self->o('genomic_features_mart'),
                        'max_dropdown' => $self->o('max_dropdown'),
                        'base_name' => $self->o('base_name') },
-      -analysis_capacity => 1
+      -analysis_capacity => 1,
+      -rc_name           => 'mem'
     },
     {
       -logic_name      => 'ScheduleSpecies',


### PR DESCRIPTION
… one Drosophila chr name was longer than 40 char. Generate_meta need more memory to run