### PR TITLE
The last two releases zebrafish ran out of indexes during the post bu…

### DIFF
--- a/martbuilder_xml/v97_xml/ensembl_template_97.xml
+++ b/martbuilder_xml/v97_xml/ensembl_template_97.xml
@@ -1,0 +1,5087 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mart PUBLIC "-//EBI//DTD MartBuilder 0.7-//EBI//DTD MartBuilder " "http://www.biomart.org/DTD/MartBuilder-0.7.dtd">
+<mart outputDatabase="division_mart_%EG%" outputSchema="division_mart_%EG%" outputHost="localhost" outputPort="18002" overrideHost="%HOST%" overridePort="%PORT%" nameCase="0" hideMaskedDataSets="false" hideMaskedSchemas="true">
+	<jdbcSchema uniqueId="1" driverClassName="com.mysql.jdbc.Driver" url="jdbc:mysql://%HOST%:%PORT%/master_schema_%ENS%" databaseName="master_schema_%ENS%" schemaName="master_schema_%ENS%" username="%USER%" password="%PASS%" name="ensembl" keyguessing="true" masked="false" hideMasked="true" partitionRegex="^(.)[^_]+_?[a-z0-9]+?_([a-z0-9]+)_core_%PARTITION_REGEX%_[0-9]*$" partitionExpression="%PARTITION_EXPRESSION%">
+		<table uniqueId="82" id="1" name="seq_region_synonym" ignore="false" inSchemaPartition="core_species_list">
+			<column id="2" name="seq_region_id" visibleModified="false"/>
+			<column id="3" name="synonym" visibleModified="false"/>
+			<column id="4" name="seq_region_synonym_id" visibleModified="false"/>
+			<column id="5" name="external_db_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="6" columnIds="4" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="7" columnIds="5" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="8" columnIds="2" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="38" id="9" name="misc_feature_misc_set" ignore="false" inSchemaPartition="core_species_list">
+			<column id="10" name="misc_feature_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="11" name="misc_set_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="12" columnIds="10,11" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="13" columnIds="11" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="14" columnIds="10" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="33" id="15" name="marker_synonym" ignore="false" inSchemaPartition="core_species_list">
+			<column id="16" name="marker_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="17" name="name" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="18" name="source" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="19" name="marker_synonym_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="20" columnIds="19" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="21" columnIds="16" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="60" id="22" name="seq_region_attrib" ignore="false" inSchemaPartition="core_species_list">
+			<column id="23" name="seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="24" name="attrib_type_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="25" name="value" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<foreignKey id="26" columnIds="24" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="27" columnIds="23" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="90" id="28" name="transcript_intron_supporting_evidence" ignore="true" inSchemaPartition="core_species_list">
+			<column id="29" name="transcript_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="30" name="intron_supporting_evidence_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="31" name="next_exon_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="32" name="previous_exon_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="33" columnIds="30,29" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="34" columnIds="29" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="35" columnIds="30" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="13" id="36" name="dna_align_feature" ignore="false" inSchemaPartition="core_species_list">
+			<column id="37" name="cigar_line" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="38" name="align_type" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="39" name="hcoverage" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="40" name="hit_strand" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="41" name="evalue" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="42" name="seq_region_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="43" name="hit_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="44" name="analysis_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="45" name="score" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="46" name="seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="47" name="perc_ident" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="48" name="hit_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="49" name="external_db_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="50" name="seq_region_strand" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="51" name="dna_align_feature_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="52" name="seq_region_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="53" name="hit_name" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="54" columnIds="51" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="55" columnIds="44" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="56" columnIds="49" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="57" columnIds="46" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="72" id="58" name="unmapped_object" ignore="false" inSchemaPartition="core_species_list">
+			<column id="59" name="query_score" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="60" name="parent" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="61" name="identifier" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="62" name="external_db_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="63" name="target_score" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="64" name="unmapped_reason_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="65" name="ensembl_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="66" name="type" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="67" name="ensembl_object_type" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="68" name="analysis_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="69" name="unmapped_object_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="70" columnIds="69" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="71" columnIds="68" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="72" columnIds="64" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="73" columnIds="62" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="44" id="74" name="peptide_archive" ignore="false" inSchemaPartition="core_species_list">
+			<column id="75" name="peptide_archive_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="76" name="md5_checksum" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="77" name="peptide_seq" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="78" columnIds="75" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="27" id="79" name="karyotype" ignore="false" inSchemaPartition="core_species_list">
+			<column id="80" name="karyotype_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="81" name="seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="82" name="band" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="83" name="seq_region_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="84" name="seq_region_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="85" name="stain" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="86" columnIds="80" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="87" columnIds="81" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="96" id="88" name="dna_align_feature_attrib" ignore="false" inSchemaPartition="core_species_list">
+			<column id="89" name="dna_align_feature_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="90" name="attrib_type_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="91" name="value" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<foreignKey id="92" columnIds="89" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="93" columnIds="90" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="12" id="94" name="dna" ignore="false" inSchemaPartition="core_species_list">
+			<column id="95" name="sequence" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="96" name="seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="97" columnIds="96" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="98" columnIds="96" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="7" id="99" name="coord_system" ignore="false" inSchemaPartition="core_species_list">
+			<column id="100" name="species_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="101" name="coord_system_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="102" name="attrib" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="103" name="name" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="104" name="rank" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="105" name="version" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="106" columnIds="101" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="11" id="107" name="ditag_feature" ignore="false" inSchemaPartition="core_species_list">
+			<column id="108" name="cigar_line" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="109" name="ditag_pair_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="110" name="hit_strand" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="111" name="seq_region_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="112" name="hit_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="113" name="analysis_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="114" name="seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="115" name="hit_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="116" name="ditag_feature_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="117" name="ditag_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="118" name="seq_region_strand" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="119" name="ditag_side" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="120" name="seq_region_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="121" columnIds="116" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="122" columnIds="117" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="123" columnIds="113" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="124" columnIds="114" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="65" id="125" name="transcript_attrib" ignore="false" inSchemaPartition="core_species_list">
+			<column id="126" name="transcript_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="127" name="attrib_type_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="128" name="value" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<foreignKey id="129" columnIds="127" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="130" columnIds="126" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="32" id="131" name="marker_map_location" ignore="false" inSchemaPartition="core_species_list">
+			<column id="132" name="lod_score" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="133" name="map_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="134" name="marker_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="135" name="chromosome_name" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="136" name="position" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="137" name="marker_synonym_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="138" columnIds="134,133" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="139" columnIds="137" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="140" columnIds="133" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="141" columnIds="134" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="95" id="142" name="genome_statistics" ignore="false" inSchemaPartition="core_species_list">
+			<column id="143" name="species_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="144" name="statistic" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="145" name="attrib_type_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="146" name="value" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="147" name="genome_statistics_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="148" name="timestamp" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="149" columnIds="147" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="150" columnIds="145" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="31" id="151" name="marker_feature" ignore="false" inSchemaPartition="core_species_list">
+			<column id="152" name="seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="153" name="map_weight" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="154" name="marker_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="155" name="marker_feature_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="156" name="seq_region_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="157" name="analysis_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="158" name="seq_region_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="159" columnIds="155" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="160" columnIds="157" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="161" columnIds="154" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="162" columnIds="152" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="36" id="163" name="misc_attrib" ignore="false" inSchemaPartition="core_species_list">
+			<column id="164" name="misc_feature_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="165" name="attrib_type_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="166" name="value" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<foreignKey id="167" columnIds="165" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="168" columnIds="164" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="88" id="169" name="data_file" ignore="false" inSchemaPartition="core_species_list">
+			<column id="170" name="data_file_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="171" name="coord_system_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="172" name="version_lock" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="173" name="absolute" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="174" name="file_type" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="175" name="name" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="176" name="analysis_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="177" name="url" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="178" columnIds="170" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="179" columnIds="176" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="180" columnIds="171" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="21" id="181" name="gene_archive" ignore="false" inSchemaPartition="core_species_list">
+			<column id="182" name="mapping_session_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="183" name="transcript_stable_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="184" name="peptide_archive_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="185" name="translation_stable_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="186" name="transcript_version" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="187" name="translation_version" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="188" name="gene_stable_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="189" name="gene_version" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<foreignKey id="190" columnIds="182" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="191" columnIds="184" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="58" id="192" name="repeat_feature" ignore="false" inSchemaPartition="core_species_list">
+			<column id="193" name="score" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="194" name="seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="195" name="repeat_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="196" name="repeat_consensus_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="197" name="seq_region_strand" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="198" name="seq_region_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="199" name="repeat_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="200" name="analysis_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="201" name="repeat_feature_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="202" name="seq_region_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="203" columnIds="201" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="204" columnIds="196" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="205" columnIds="200" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="206" columnIds="194" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="74" id="207" name="xref" ignore="false" inSchemaPartition="core_species_list">
+			<column id="208" name="display_label" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="209" name="info_type" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="210" name="info_text" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="211" name="external_db_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="212" name="dbprimary_acc" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="213" name="description" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="214" name="xref_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="215" name="version" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="216" columnIds="214" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="217" columnIds="211" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="218" columnIds="212" status="HANDMADE" visibleModified="false"/>
+		</table>
+		<table uniqueId="39" id="219" name="misc_set" ignore="false" inSchemaPartition="core_species_list">
+			<column id="220" name="code" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="221" name="name" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="222" name="description" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="223" name="max_length" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="224" name="misc_set_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="225" columnIds="224" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="20" id="226" name="gene" ignore="false" inSchemaPartition="core_species_list">
+			<column id="227" name="biotype" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="228" name="stable_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="229" name="description" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="230" name="seq_region_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="231" name="source" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="232" name="modified_date" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="233" name="version" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="234" name="display_xref_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="235" name="analysis_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="236" name="canonical_transcript_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="237" name="seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="238" name="seq_region_strand" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="239" name="created_date" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="240" name="is_current" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="241" name="gene_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="242" name="seq_region_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="243" columnIds="241" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="244" columnIds="235" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="245" columnIds="237" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="246" columnIds="234" status="HANDMADE" visibleModified="false"/>
+			<foreignKey id="247" columnIds="236" status="HANDMADE" visibleModified="false"/>
+			<foreignKey id="248" columnIds="228" status="HANDMADE" visibleModified="false"/>
+		</table>
+		<table uniqueId="24" id="249" name="ontology_xref" ignore="false" inSchemaPartition="core_species_list">
+			<column id="250" name="linkage_type" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="251" name="source_xref_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="252" name="object_xref_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<foreignKey id="253" columnIds="252" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="93" id="254" name="alt_allele_attrib" ignore="false" inSchemaPartition="core_species_list">
+			<column id="255" name="attrib" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="256" name="alt_allele_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<foreignKey id="257" columnIds="256" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="57" id="258" name="repeat_consensus" ignore="false" inSchemaPartition="core_species_list">
+			<column id="259" name="repeat_type" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="260" name="repeat_consensus_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="261" name="repeat_class" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="262" name="repeat_name" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="263" name="repeat_consensus" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="264" columnIds="260" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="2" id="265" name="analysis" ignore="false" inSchemaPartition="core_species_list">
+			<column id="266" name="logic_name" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="267" name="program_version" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="268" name="gff_feature" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="269" name="created" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="270" name="module" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="271" name="db_file" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="272" name="program_file" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="273" name="program" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="274" name="module_version" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="275" name="analysis_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="276" name="db_version" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="277" name="gff_source" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="278" name="parameters" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="279" name="db" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="280" columnIds="275" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="26" id="281" name="interpro" ignore="false" inSchemaPartition="core_species_list">
+			<column id="282" name="interpro_ac" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="283" name="id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<foreignKey id="284" columnIds="283" status="HANDMADE" visibleModified="false"/>
+			<foreignKey id="285" columnIds="282" status="HANDMADE" visibleModified="false"/>
+		</table>
+		<table uniqueId="92" id="286" name="associated_xref" ignore="false" inSchemaPartition="core_species_list">
+			<column id="287" name="source_xref_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="288" name="condition_type" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="289" name="object_xref_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="290" name="rank" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="291" name="xref_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="292" name="associated_xref_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="293" name="associated_group_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="294" columnIds="292" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="295" columnIds="293" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="296" columnIds="289" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="297" columnIds="291" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="17" id="298" name="exon_transcript" ignore="false" inSchemaPartition="core_species_list">
+			<column id="299" name="transcript_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="300" name="exon_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="301" name="rank" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="302" columnIds="300,299,301" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="303" columnIds="300" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="304" columnIds="299" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="9" id="305" name="density_type" ignore="false" inSchemaPartition="core_species_list">
+			<column id="306" name="value_type" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="307" name="density_type_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="308" name="region_features" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="309" name="block_size" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="310" name="analysis_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="311" columnIds="307" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="312" columnIds="310" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="37" id="313" name="misc_feature" ignore="false" inSchemaPartition="core_species_list">
+			<column id="314" name="seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="315" name="misc_feature_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="316" name="seq_region_strand" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="317" name="seq_region_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="318" name="seq_region_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="319" columnIds="315" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="320" columnIds="314" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="30" id="321" name="marker" ignore="false" inSchemaPartition="core_species_list">
+			<column id="322" name="left_primer" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="323" name="marker_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="324" name="right_primer" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="325" name="priority" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="326" name="type" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="327" name="min_primer_dist" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="328" name="display_marker_synonym_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="329" name="max_primer_dist" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="330" columnIds="323" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="34" id="331" name="meta" ignore="false" inSchemaPartition="core_species_list">
+			<column id="332" name="species_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="333" name="meta_value" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="334" name="meta_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="335" name="meta_key" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="336" columnIds="334" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="76" id="337" name="seq_region_mapping" ignore="false" inSchemaPartition="core_species_list">
+			<column id="338" name="mapping_set_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="339" name="internal_seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="340" name="external_seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<foreignKey id="341" columnIds="338" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="18" id="342" name="external_db" ignore="false" inSchemaPartition="core_species_list">
+			<column id="343" name="secondary_db_table" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="344" name="db_name" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="345" name="db_release" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="346" name="external_db_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="347" name="db_display_name" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="348" name="description" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="349" name="secondary_db_name" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="350" name="priority" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="351" name="type" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="352" name="status" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="353" columnIds="346" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="48" id="354" name="protein_feature" ignore="false" inSchemaPartition="core_species_list">
+			<column id="355" name="cigar_line" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="356" name="align_type" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="357" name="translation_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="358" name="external_data" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="359" name="evalue" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="360" name="hit_description" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="361" name="hit_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="362" name="analysis_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="363" name="seq_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="364" name="score" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="365" name="perc_ident" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="366" name="hit_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="367" name="seq_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="368" name="protein_feature_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="369" name="hit_name" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="370" columnIds="368" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="371" columnIds="362" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="372" columnIds="357" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="373" columnIds="369" status="HANDMADE" visibleModified="false"/>
+		</table>
+		<table uniqueId="85" id="374" name="operon_transcript" ignore="false" inSchemaPartition="core_species_list">
+			<column id="375" name="display_label" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="376" name="operon_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="377" name="stable_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="378" name="seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="379" name="operon_transcript_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="380" name="seq_region_strand" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="381" name="created_date" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="382" name="seq_region_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="383" name="modified_date" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="384" name="version" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="385" name="analysis_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="386" name="seq_region_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="387" columnIds="379" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="388" columnIds="376" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="389" columnIds="385" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="390" columnIds="378" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="67" id="391" name="transcript_supporting_feature" ignore="false" inSchemaPartition="core_species_list">
+			<column id="392" name="feature_type" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="393" name="feature_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="394" name="transcript_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<foreignKey id="395" columnIds="394" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="62" id="396" name="stable_id_event" ignore="false" inSchemaPartition="core_species_list">
+			<column id="397" name="old_stable_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="398" name="new_stable_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="399" name="mapping_session_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="400" name="score" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="401" name="old_version" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="402" name="new_version" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="403" name="type" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<foreignKey id="404" columnIds="399" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="10" id="405" name="ditag" ignore="false" inSchemaPartition="core_species_list">
+			<column id="406" name="sequence" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="407" name="tag_count" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="408" name="ditag_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="409" name="name" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="410" name="type" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="411" columnIds="408" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="59" id="412" name="seq_region" ignore="false" inSchemaPartition="core_species_list">
+			<column id="413" name="seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="414" name="coord_system_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="415" name="name" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="416" name="length" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="417" columnIds="413" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="418" columnIds="414" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="75" id="419" name="mapping_set" ignore="false" inSchemaPartition="core_species_list">
+			<column id="420" name="external_schema_build" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="421" name="mapping_set_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="422" name="internal_schema_build" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="423" columnIds="421" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="64" id="424" name="transcript" ignore="false" inSchemaPartition="core_species_list">
+			<column id="425" name="biotype" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="426" name="stable_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="427" name="description" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="428" name="seq_region_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="429" name="source" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="430" name="modified_date" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="431" name="version" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="432" name="display_xref_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="433" name="analysis_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="434" name="seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="435" name="transcript_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="436" name="canonical_translation_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="437" name="seq_region_strand" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="438" name="created_date" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="439" name="is_current" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="440" name="gene_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="441" name="seq_region_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="442" columnIds="435" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="443" columnIds="440" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="444" columnIds="433" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="445" columnIds="434" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="446" columnIds="432" status="HANDMADE" visibleModified="false"/>
+			<foreignKey id="447" columnIds="426" status="HANDMADE" visibleModified="false"/>
+		</table>
+		<table uniqueId="86" id="448" name="operon_transcript_gene" ignore="false" inSchemaPartition="core_species_list">
+			<column id="449" name="operon_transcript_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="450" name="gene_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<foreignKey id="451" columnIds="450" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="452" columnIds="449" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="61" id="453" name="simple_feature" ignore="false" inSchemaPartition="core_species_list">
+			<column id="454" name="display_label" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="455" name="score" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="456" name="seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="457" name="simple_feature_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="458" name="seq_region_strand" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="459" name="seq_region_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="460" name="analysis_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="461" name="seq_region_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="462" columnIds="457" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="463" columnIds="460" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="464" columnIds="456" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="4" id="465" name="assembly" ignore="false" inSchemaPartition="core_species_list">
+			<column id="466" name="cmp_seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="467" name="asm_seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="468" name="cmp_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="469" name="asm_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="470" name="cmp_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="471" name="ori" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="472" name="asm_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+		</table>
+		<table uniqueId="69" id="473" name="translation_attrib" ignore="false" inSchemaPartition="core_species_list">
+			<column id="474" name="translation_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="475" name="attrib_type_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="476" name="value" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<foreignKey id="477" columnIds="475" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="478" columnIds="474" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="28" id="479" name="map" ignore="false" inSchemaPartition="core_species_list">
+			<column id="480" name="map_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="481" name="map_name" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="482" columnIds="480" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="6" id="483" name="attrib_type" ignore="false" inSchemaPartition="core_species_list">
+			<column id="484" name="code" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="485" name="name" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="486" name="description" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="487" name="attrib_type_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="488" columnIds="487" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="89" id="489" name="intron_supporting_evidence" ignore="false" inSchemaPartition="core_species_list">
+			<column id="490" name="is_splice_canonical" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="491" name="score" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="492" name="seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="493" name="intron_supporting_evidence_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="494" name="seq_region_strand" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="495" name="seq_region_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="496" name="analysis_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="497" name="score_type" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="498" name="seq_region_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="499" name="hit_name" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="500" columnIds="493" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="501" columnIds="492" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="502" columnIds="496" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="73" id="503" name="unmapped_reason" ignore="false" inSchemaPartition="core_species_list">
+			<column id="504" name="full_description" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="505" name="unmapped_reason_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="506" name="summary_description" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="507" columnIds="505" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="45" id="508" name="prediction_exon" ignore="false" inSchemaPartition="core_species_list">
+			<column id="509" name="p_value" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="510" name="score" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="511" name="seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="512" name="seq_region_strand" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="513" name="prediction_transcript_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="514" name="prediction_exon_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="515" name="seq_region_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="516" name="exon_rank" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="517" name="seq_region_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="518" name="start_phase" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="519" columnIds="514" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="520" columnIds="513" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="521" columnIds="511" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="29" id="522" name="mapping_session" ignore="false" inSchemaPartition="core_species_list">
+			<column id="523" name="mapping_session_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="524" name="new_assembly" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="525" name="new_release" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="526" name="created" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="527" name="new_db_name" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="528" name="old_assembly" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="529" name="old_db_name" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="530" name="old_release" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="531" columnIds="523" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="97" id="532" name="biotype" ignore="false" inSchemaPartition="core_species_list">
+			<column id="533" name="biotype_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="534" name="db_type" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="535" name="object_type" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="536" name="biotype_group" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="537" name="name" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="538" name="so_acc" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="539" name="description" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="540" name="attrib_type_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="541" columnIds="533" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="542" columnIds="540" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="77" id="543" name="dependent_xref" ignore="false" inSchemaPartition="core_species_list">
+			<column id="544" name="object_xref_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="545" name="dependent_xref_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="546" name="master_xref_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="547" columnIds="544" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="548" columnIds="544" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="19" id="549" name="external_synonym" ignore="false" inSchemaPartition="core_species_list">
+			<column id="550" name="synonym" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="551" name="xref_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="552" columnIds="551,550" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="553" columnIds="551" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="91" id="554" name="associated_group" ignore="false" inSchemaPartition="core_species_list">
+			<column id="555" name="description" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="556" name="associated_group_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="557" columnIds="556" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="1" id="558" name="alt_allele" ignore="false" inSchemaPartition="core_species_list">
+			<column id="559" name="alt_allele_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="560" name="alt_allele_group_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="561" name="gene_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="562" columnIds="559" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="563" columnIds="561" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="564" columnIds="560" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="5" id="565" name="assembly_exception" ignore="false" inSchemaPartition="core_species_list">
+			<column id="566" name="exc_seq_region_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="567" name="seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="568" name="exc_seq_region_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="569" name="exc_seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="570" name="assembly_exception_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="571" name="ori" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="572" name="exc_type" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="573" name="seq_region_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="574" name="seq_region_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="575" columnIds="570" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="576" columnIds="567" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="3" id="577" name="analysis_description" ignore="false" inSchemaPartition="core_species_list">
+			<column id="578" name="display_label" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="579" name="web_data" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="580" name="displayable" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="581" name="description" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="582" name="analysis_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<foreignKey id="583" columnIds="582" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="83" id="584" name="operon" ignore="false" inSchemaPartition="core_species_list">
+			<column id="585" name="display_label" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="586" name="operon_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="587" name="stable_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="588" name="seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="589" name="seq_region_strand" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="590" name="created_date" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="591" name="seq_region_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="592" name="modified_date" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="593" name="version" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="594" name="analysis_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="595" name="seq_region_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="596" columnIds="586" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="597" columnIds="594" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="598" columnIds="588" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="8" id="599" name="density_feature" ignore="false" inSchemaPartition="core_species_list">
+			<column id="600" name="seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="601" name="density_feature_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="602" name="density_value" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="603" name="density_type_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="604" name="seq_region_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="605" name="seq_region_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="606" columnIds="601" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="607" columnIds="603" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="608" columnIds="600" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="47" id="609" name="protein_align_feature" ignore="false" inSchemaPartition="core_species_list">
+			<column id="610" name="cigar_line" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="611" name="align_type" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="612" name="hcoverage" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="613" name="evalue" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="614" name="seq_region_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="615" name="hit_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="616" name="analysis_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="617" name="score" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="618" name="seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="619" name="perc_ident" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="620" name="hit_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="621" name="external_db_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="622" name="seq_region_strand" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="623" name="protein_align_feature_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="624" name="seq_region_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="625" name="hit_name" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="626" columnIds="623" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="627" columnIds="616" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="628" columnIds="621" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="629" columnIds="618" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="25" id="630" name="identity_xref" ignore="false" inSchemaPartition="core_species_list">
+			<column id="631" name="xref_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="632" name="ensembl_identity" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="633" name="score" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="634" name="xref_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="635" name="cigar_line" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="636" name="xref_identity" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="637" name="ensembl_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="638" name="ensembl_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="639" name="object_xref_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="640" name="evalue" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="641" columnIds="639" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="642" columnIds="639" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="46" id="643" name="prediction_transcript" ignore="false" inSchemaPartition="core_species_list">
+			<column id="644" name="display_label" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="645" name="seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="646" name="seq_region_strand" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="647" name="prediction_transcript_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="648" name="seq_region_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="649" name="analysis_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="650" name="seq_region_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="651" columnIds="647" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="652" columnIds="649" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="653" columnIds="645" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="35" id="654" name="meta_coord" ignore="false" inSchemaPartition="core_species_list">
+			<column id="655" name="coord_system_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="656" name="table_name" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="657" name="max_length" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<foreignKey id="658" columnIds="655" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="68" id="659" name="translation" ignore="false" inSchemaPartition="core_species_list">
+			<column id="660" name="seq_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="661" name="stable_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="662" name="transcript_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="663" name="translation_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="664" name="start_exon_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="665" name="seq_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="666" name="end_exon_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="667" name="created_date" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="668" name="modified_date" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="669" name="version" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="670" columnIds="663" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="671" columnIds="662" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="63" id="672" name="supporting_feature" ignore="false" inSchemaPartition="core_species_list">
+			<column id="673" name="feature_type" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="674" name="feature_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="675" name="exon_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<foreignKey id="676" columnIds="675" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="40" id="677" name="object_xref" ignore="false" inSchemaPartition="core_species_list">
+			<column id="678" name="linkage_annotation" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="679" name="object_xref_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="680" name="ensembl_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="681" name="xref_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="682" name="ensembl_object_type" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="683" name="analysis_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="684" columnIds="679" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="685" columnIds="681" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="686" columnIds="680" status="HANDMADE" visibleModified="false"/>
+			<foreignKey id="687" columnIds="683" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="15" id="688" name="exon" ignore="false" inSchemaPartition="core_species_list">
+			<column id="689" name="phase" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="690" name="stable_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="691" name="exon_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="692" name="seq_region_end" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="693" name="modified_date" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="694" name="version" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="695" name="end_phase" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="696" name="seq_region_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="697" name="is_constitutive" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="698" name="seq_region_strand" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="699" name="created_date" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="700" name="is_current" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="701" name="seq_region_start" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="702" columnIds="691" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="703" columnIds="696" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="94" id="704" name="alt_allele_group" ignore="false" inSchemaPartition="core_species_list">
+			<column id="705" name="alt_allele_group_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<primaryKey id="706" columnIds="705" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="22" id="707" name="gene_attrib" ignore="false" inSchemaPartition="core_species_list">
+			<column id="708" name="attrib_type_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="709" name="value" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<column id="710" name="gene_id" visibleModified="false" inSchemaPartition="core_species_list"/>
+			<foreignKey id="711" columnIds="710" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="712" columnIds="708" status="INFERRED" visibleModified="false"/>
+		</table>
+		<relation id="713" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="54" secondKeyId="92" status="INFERRED" visibleModified="false"/>
+		<relation id="714" cardinality="1" originalCardinality="M(a)" firstKeyId="417" secondKeyId="27" status="MODIFIED" visibleModified="false"/>
+		<relation id="715" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="442" secondKeyId="130" status="INFERRED" visibleModified="false"/>
+		<relation id="716" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="280" secondKeyId="502" status="INFERRED" visibleModified="false"/>
+		<relation id="717" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="417" secondKeyId="390" status="INFERRED" visibleModified="false"/>
+		<relation id="718" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="651" secondKeyId="520" status="INFERRED" visibleModified="false"/>
+		<relation id="719" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="280" secondKeyId="687" status="INFERRED_INCORRECT" visibleModified="false"/>
+		<relation id="720" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="417" secondKeyId="653" status="INFERRED" visibleModified="false"/>
+		<relation id="721" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="280" secondKeyId="179" status="INFERRED" visibleModified="false"/>
+		<relation id="722" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="216" secondKeyId="297" status="INFERRED" visibleModified="false"/>
+		<relation id="723" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="280" secondKeyId="312" status="INFERRED" visibleModified="false"/>
+		<relation id="724" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="423" secondKeyId="341" status="INFERRED" visibleModified="false"/>
+		<relation id="725" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="417" secondKeyId="98" status="INFERRED" visibleModified="false"/>
+		<relation id="726" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="417" secondKeyId="162" status="INFERRED" visibleModified="false"/>
+		<relation id="727" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="353" secondKeyId="217" status="INFERRED" visibleModified="false"/>
+		<relation id="728" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="280" secondKeyId="627" status="INFERRED" visibleModified="false"/>
+		<relation id="729" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="243" secondKeyId="443" status="INFERRED" visibleModified="false"/>
+		<relation id="730" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="417" secondKeyId="521" status="INFERRED" visibleModified="false"/>
+		<relation id="731" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="482" secondKeyId="140" status="INFERRED" visibleModified="false"/>
+		<relation id="732" cardinality="1" originalCardinality="M(a)" firstKeyId="216" secondKeyId="553" status="MODIFIED" visibleModified="false"/>
+		<relation id="733" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="684" secondKeyId="548" status="INFERRED" visibleModified="false"/>
+		<relation id="734" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="417" secondKeyId="464" status="INFERRED" visibleModified="false"/>
+		<relation id="735" cardinality="1" originalCardinality="M(a)" firstKeyId="319" secondKeyId="168" status="MODIFIED" visibleModified="false"/>
+		<relation id="736" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="488" secondKeyId="150" status="INFERRED" visibleModified="false"/>
+		<relation id="737" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="280" secondKeyId="389" status="INFERRED" visibleModified="false"/>
+		<relation id="738" cardinality="1" originalCardinality="M(a)" firstKeyId="670" secondKeyId="478" status="MODIFIED" visibleModified="false"/>
+		<relation id="739" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="353" secondKeyId="73" status="INFERRED" visibleModified="false"/>
+		<relation id="740" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="442" secondKeyId="34" status="INFERRED" visibleModified="false"/>
+		<relation id="741" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="488" secondKeyId="712" status="INFERRED" visibleModified="false"/>
+		<relation id="742" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="442" secondKeyId="304" status="INFERRED" visibleModified="false"/>
+		<relation id="743" cardinality="M(b)" originalCardinality="M(a)" firstKeyId="373" secondKeyId="284" status="HANDMADE" visibleModified="false"/>
+		<relation id="744" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="87" secondKeyId="245" status="HANDMADE" visibleModified="false"/>
+		<relation id="745" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="702" secondKeyId="676" status="INFERRED" visibleModified="false"/>
+		<relation id="746" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="670" secondKeyId="372" status="INFERRED" visibleModified="false"/>
+		<relation id="747" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="106" secondKeyId="180" status="INFERRED" visibleModified="false"/>
+		<relation id="748" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="562" secondKeyId="257" status="INFERRED" visibleModified="false"/>
+		<relation id="749" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="417" secondKeyId="629" status="INFERRED" visibleModified="false"/>
+		<relation id="750" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="417" secondKeyId="87" status="INFERRED_INCORRECT" visibleModified="false"/>
+		<relation id="751" cardinality="M(b)" originalCardinality="M(a)" firstKeyId="320" secondKeyId="245" status="HANDMADE" visibleModified="false"/>
+		<relation id="752" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="442" secondKeyId="671" status="INFERRED" visibleModified="false"/>
+		<relation id="753" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="353" secondKeyId="7" status="INFERRED" visibleModified="false"/>
+		<relation id="754" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="488" secondKeyId="542" status="INFERRED" visibleModified="false"/>
+		<relation id="755" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="216" secondKeyId="685" status="INFERRED" visibleModified="false"/>
+		<relation id="756" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="507" secondKeyId="72" status="INFERRED" visibleModified="false"/>
+		<relation id="757" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="417" secondKeyId="445" status="INFERRED" visibleModified="false"/>
+		<relation id="758" cardinality="M(b)" originalCardinality="M(b)" firstKeyId="446" secondKeyId="216" status="HANDMADE" visibleModified="false"/>
+		<relation id="759" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="488" secondKeyId="26" status="INFERRED" visibleModified="false"/>
+		<relation id="760" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="596" secondKeyId="388" status="INFERRED" visibleModified="false"/>
+		<relation id="761" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="417" secondKeyId="320" status="INFERRED_INCORRECT" visibleModified="false"/>
+		<relation id="762" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="280" secondKeyId="244" status="INFERRED" visibleModified="false"/>
+		<relation id="763" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="488" secondKeyId="477" status="INFERRED" visibleModified="false"/>
+		<relation id="764" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="488" secondKeyId="167" status="INFERRED" visibleModified="false"/>
+		<relation id="765" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="417" secondKeyId="8" status="INFERRED" visibleModified="false"/>
+		<relation id="766" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="442" secondKeyId="395" status="INFERRED" visibleModified="false"/>
+		<relation id="767" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="20" secondKeyId="139" status="INFERRED" visibleModified="false"/>
+		<relation id="768" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="106" secondKeyId="418" status="INFERRED" visibleModified="false"/>
+		<relation id="769" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="243" secondKeyId="563" status="INFERRED" visibleModified="false"/>
+		<relation id="770" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="311" secondKeyId="607" status="INFERRED" visibleModified="false"/>
+		<relation id="771" cardinality="1" originalCardinality="M(a)" firstKeyId="243" secondKeyId="711" status="MODIFIED" visibleModified="false"/>
+		<relation id="772" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="243" secondKeyId="451" status="INFERRED" visibleModified="false"/>
+		<relation id="773" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="684" secondKeyId="642" status="INFERRED" visibleModified="false"/>
+		<relation id="774" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="417" secondKeyId="703" status="INFERRED" visibleModified="false"/>
+		<relation id="775" cardinality="M(b)" originalCardinality="M(b)" firstKeyId="686" secondKeyId="243" status="HANDMADE" visibleModified="false"/>
+		<relation id="776" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="417" secondKeyId="608" status="INFERRED" visibleModified="false"/>
+		<relation id="777" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="417" secondKeyId="598" status="INFERRED" visibleModified="false"/>
+		<relation id="778" cardinality="M(b)" originalCardinality="M(b)" firstKeyId="686" secondKeyId="442" status="HANDMADE" visibleModified="false"/>
+		<relation id="779" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="319" secondKeyId="14" status="INFERRED" visibleModified="false"/>
+		<relation id="780" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="387" secondKeyId="452" status="INFERRED" visibleModified="false"/>
+		<relation id="781" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="417" secondKeyId="245" status="INFERRED" visibleModified="false"/>
+		<relation id="782" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="280" secondKeyId="444" status="INFERRED" visibleModified="false"/>
+		<relation id="783" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="417" secondKeyId="576" status="INFERRED" visibleModified="false"/>
+		<relation id="784" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="280" secondKeyId="463" status="INFERRED" visibleModified="false"/>
+		<relation id="785" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="488" secondKeyId="129" status="INFERRED" visibleModified="false"/>
+		<relation id="786" cardinality="1" originalCardinality="M(a)" firstKeyId="684" secondKeyId="253" status="MODIFIED" visibleModified="false"/>
+		<relation id="787" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="225" secondKeyId="13" status="INFERRED" visibleModified="false"/>
+		<relation id="788" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="531" secondKeyId="404" status="INFERRED" visibleModified="false"/>
+		<relation id="789" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="280" secondKeyId="71" status="INFERRED" visibleModified="false"/>
+		<relation id="790" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="78" secondKeyId="191" status="INFERRED" visibleModified="false"/>
+		<relation id="791" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="106" secondKeyId="658" status="INFERRED" visibleModified="false"/>
+		<relation id="792" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="417" secondKeyId="124" status="INFERRED" visibleModified="false"/>
+		<relation id="793" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="330" secondKeyId="161" status="INFERRED" visibleModified="false"/>
+		<relation id="794" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="488" secondKeyId="93" status="INFERRED" visibleModified="false"/>
+		<relation id="795" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="280" secondKeyId="583" status="INFERRED" visibleModified="false"/>
+		<relation id="796" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="330" secondKeyId="21" status="INFERRED" visibleModified="false"/>
+		<relation id="797" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="411" secondKeyId="122" status="INFERRED" visibleModified="false"/>
+		<relation id="798" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="280" secondKeyId="205" status="INFERRED" visibleModified="false"/>
+		<relation id="799" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="531" secondKeyId="190" status="INFERRED" visibleModified="false"/>
+		<relation id="800" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="280" secondKeyId="55" status="INFERRED" visibleModified="false"/>
+		<relation id="801" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="264" secondKeyId="204" status="INFERRED" visibleModified="false"/>
+		<relation id="802" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="684" secondKeyId="296" status="INFERRED" visibleModified="false"/>
+		<relation id="803" cardinality="M(b)" originalCardinality="M(b)" firstKeyId="246" secondKeyId="216" status="HANDMADE" visibleModified="false"/>
+		<relation id="804" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="330" secondKeyId="141" status="INFERRED" visibleModified="false"/>
+		<relation id="805" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="417" secondKeyId="501" status="INFERRED" visibleModified="false"/>
+		<relation id="806" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="500" secondKeyId="35" status="INFERRED" visibleModified="false"/>
+		<relation id="807" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="280" secondKeyId="123" status="INFERRED" visibleModified="false"/>
+		<relation id="808" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="353" secondKeyId="56" status="INFERRED" visibleModified="false"/>
+		<relation id="809" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="417" secondKeyId="57" status="INFERRED" visibleModified="false"/>
+		<relation id="810" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="417" secondKeyId="206" status="INFERRED" visibleModified="false"/>
+		<relation id="811" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="557" secondKeyId="295" status="INFERRED" visibleModified="false"/>
+		<relation id="812" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="280" secondKeyId="652" status="INFERRED" visibleModified="false"/>
+		<relation id="813" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="706" secondKeyId="564" status="INFERRED" visibleModified="false"/>
+		<relation id="814" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="670" secondKeyId="686" status="HANDMADE" visibleModified="false"/>
+		<relation id="815" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="280" secondKeyId="597" status="INFERRED" visibleModified="false"/>
+		<relation id="816" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="280" secondKeyId="160" status="INFERRED" visibleModified="false"/>
+		<relation id="817" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="280" secondKeyId="371" status="INFERRED" visibleModified="false"/>
+		<relation id="818" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="218" secondKeyId="285" status="HANDMADE" visibleModified="false"/>
+		<relation id="819" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="353" secondKeyId="628" status="INFERRED" visibleModified="false"/>
+		<relation id="820" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="702" secondKeyId="303" status="INFERRED" visibleModified="false"/>
+	</jdbcSchema>
+	<jdbcSchema uniqueId="11" driverClassName="com.mysql.jdbc.Driver" url="jdbc:mysql://%HOST%:%PORT%/master_schema_funcgen_%ENS%" databaseName="master_schema_funcgen_%ENS%" schemaName="master_schema_funcgen_%ENS%" username="%USER%" password="%PASS%" name="functional_genomics" keyguessing="true" masked="false" hideMasked="true" partitionRegex="^(.)[^_]+_?[a-z0-9]+?_([a-z0-9]+)_funcgen_%PARTITION_REGEX%_[1-9]?[0-9]*$" partitionExpression="%PARTITION_EXPRESSION%">
+		<table uniqueId="33" id="821" name="probe_feature" ignore="true" inSchemaPartition="funcgen_species_list">
+			<column id="822" name="mismatches" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="823" name="probe_feature_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="824" name="probe_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="825" name="seq_region_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="826" name="cigar_line" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="827" name="hit_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="828" name="seq_region_strand" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="829" name="seq_region_end" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="830" name="source" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="831" name="analysis_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="832" name="seq_region_start" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="833" columnIds="823" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="834" columnIds="831" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="835" columnIds="824" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="113" id="836" name="transcription_factor_complex" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="837" name="production_name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="838" name="transcription_factor_complex_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="839" name="display_name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="840" columnIds="838" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="73" id="841" name="regulatory_build" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="842" name="initial_release_date" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="843" name="last_annotation_update" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="844" name="feature_type_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="845" name="name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="846" name="description" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="847" name="is_current" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="848" name="sample_regulatory_feature_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="849" name="release_version" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="850" name="version" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="851" name="analysis_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="852" name="regulatory_build_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="853" columnIds="852" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="854" columnIds="844" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="855" columnIds="851" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="56" id="856" name="MTMP_probestuff_helper" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="857" name="display_label" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="858" name="transcript_stable_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="859" name="array_vendor_and_name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="860" name="array_name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="861" name="is_probeset_array" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<foreignKey id="862" columnIds="858" status="HANDMADE" visibleModified="false"/>
+		</table>
+		<table uniqueId="99" id="863" name="probe_mapping" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="864" name="three_prime_utr" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="865" name="sample_probe_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="866" name="probe_mapping_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="867" name="sample_probe_set_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="868" name="release_date" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="869" name="assembly" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="870" name="gene_build_version" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="871" name="release_version" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="872" name="five_prime_utr" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="873" columnIds="866" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="44" id="874" name="unmapped_object" ignore="true" inSchemaPartition="funcgen_species_list">
+			<column id="875" name="query_score" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="876" name="parent" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="877" name="identifier" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="878" name="external_db_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="879" name="target_score" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="880" name="unmapped_reason_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="881" name="ensembl_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="882" name="type" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="883" name="ensembl_object_type" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="884" name="analysis_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="885" name="unmapped_object_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="886" columnIds="885" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="887" columnIds="880" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="888" columnIds="878" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="889" columnIds="884" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="13" id="890" name="experiment" ignore="true" inSchemaPartition="funcgen_species_list">
+			<column id="891" name="control_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="892" name="experimental_group_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="893" name="experiment_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="894" name="feature_type_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="895" name="name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="896" name="is_control" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="897" name="epigenome_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="898" name="archive_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="899" columnIds="893" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="900" columnIds="892" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="901" columnIds="894" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="902" columnIds="897" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="23" id="903" name="feature_set" ignore="true" inSchemaPartition="funcgen_species_list">
+			<column id="904" name="display_label" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="905" name="feature_set_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="906" name="feature_type_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="907" name="name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="908" name="description" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="909" name="type" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="910" name="analysis_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="911" columnIds="905" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="912" columnIds="906" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="913" columnIds="910" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="103" id="914" name="probe_transcript" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="915" name="probe_transcript_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="916" name="stable_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="917" name="probe_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="918" name="description" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="919" columnIds="915" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="920" columnIds="917" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="16" id="921" name="experimental_group" ignore="true" inSchemaPartition="funcgen_species_list">
+			<column id="922" name="experimental_group_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="923" name="production_name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="924" name="name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="925" name="description" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="926" name="is_project" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="927" name="url" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="928" columnIds="922" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="83" id="929" name="alignment_read_file" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="930" name="alignment_read_file_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="931" name="read_file_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="932" name="alignment_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="933" columnIds="930,932" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="934" columnIds="931" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="935" columnIds="932" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="105" id="936" name="read_file_experimental_configuration" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="937" name="technical_replicate" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="938" name="read_file_experimental_configuration_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="939" name="experiment_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="940" name="multiple" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="941" name="biological_replicate" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="942" name="read_file_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="943" name="paired_end_tag" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="944" columnIds="938" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="945" columnIds="939" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="946" columnIds="942" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="100" id="947" name="probe_mapping_statistic" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="948" name="array_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="949" name="statistic" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="950" name="probe_mapping_statistic_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="951" name="value" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="952" columnIds="950" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="953" columnIds="948" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="109" id="954" name="segmentation_state_assignment" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="955" name="assignment" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="956" name="segmentation_state_assignment_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="957" name="segmentation" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="958" name="state" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="959" columnIds="956" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="104" id="960" name="read_file" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="961" name="file" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="962" name="notes" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="963" name="md5sum" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="964" name="name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="965" name="read_file_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="966" name="is_paired_end" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="967" name="read_length" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="968" name="analysis_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="969" name="file_size" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="970" name="number_of_reads" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="971" columnIds="965" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="972" columnIds="968" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="87" id="973" name="data_file" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="974" name="path" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="975" name="data_file_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="976" name="file_type" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="977" name="md5sum" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="978" name="table_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="979" name="table_name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="980" columnIds="975" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="108" id="981" name="segmentation_cell_tables" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="982" name="segmentation_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="983" name="superclass" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="984" name="feature_type_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="985" name="control_alignment_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="986" name="epigenome_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="987" name="signal_alignment_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="988" name="class" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<foreignKey id="989" columnIds="982" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="990" columnIds="986" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="991" columnIds="984" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="82" id="992" name="alignment_qc_flagstats" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="993" name="path" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="994" name="bam_file" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="995" name="qc_passed_reads" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="996" name="category" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="997" name="qc_failed_reads" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="998" name="alignment_qc_flagstats_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="999" name="alignment_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1000" name="analysis_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1001" columnIds="998" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1002" columnIds="1000" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1003" columnIds="999" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="46" id="1004" name="xref" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1005" name="display_label" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1006" name="info_type" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1007" name="info_text" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1008" name="external_db_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1009" name="dbprimary_acc" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1010" name="description" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1011" name="xref_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1012" name="version" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1013" columnIds="1011" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1014" columnIds="1008" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1015" columnIds="1009" status="HANDMADE" visibleModified="false"/>
+		</table>
+		<table uniqueId="25" id="1016" name="ontology_xref" ignore="true" inSchemaPartition="funcgen_species_list">
+			<column id="1017" name="linkage_type" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1018" name="source_xref_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1019" name="object_xref_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<foreignKey id="1020" columnIds="1019" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="102" id="1021" name="probe_set_transcript" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1022" name="stable_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1023" name="probe_set_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1024" name="probe_set_transcript_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1025" name="description" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1026" columnIds="1024" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1027" columnIds="1023" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="76" id="1028" name="segmentation_file" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1029" name="segmentation_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1030" name="name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1031" name="epigenome_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1032" name="segmentation_file_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1033" name="analysis_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1034" name="regulatory_build_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1035" columnIds="1032" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1036" columnIds="1031" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1037" columnIds="1033" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1038" columnIds="1034" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1039" columnIds="1029" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="110" id="1040" name="segmentation_state_emission" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1041" name="H3K4me1" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1042" name="H3K4me3" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1043" name="H3K9me3" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1044" name="H3K27ac" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1045" name="H3K4me2" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1046" name="DNase1" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1047" name="CTCF" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1048" name="H3K36me3" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1049" name="H3K9ac" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1050" name="segmentation" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1051" name="state" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1052" name="segmentation_state_emission_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1053" name="H3K27me3" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1054" columnIds="1052" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="6" id="1055" name="associated_feature_type" ignore="true" inSchemaPartition="funcgen_species_list">
+			<column id="1056" name="feature_type_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1057" name="table_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1058" name="table_name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1059" columnIds="1057,1058,1056" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1060" columnIds="1056" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="75" id="1061" name="regulatory_evidence" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1062" name="attribute_feature_table" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1063" name="regulatory_activity_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1064" name="attribute_feature_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1065" columnIds="1063,1062,1064" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1066" columnIds="1063" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="88" id="1067" name="execution_plan" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1068" name="experiment_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1069" name="execution_plan" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1070" name="time" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1071" name="execution_plan_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1072" columnIds="1071" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1073" columnIds="1068" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="1" id="1074" name="analysis" ignore="true" inSchemaPartition="funcgen_species_list">
+			<column id="1075" name="logic_name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1076" name="program_version" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1077" name="gff_feature" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1078" name="created" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1079" name="module" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1080" name="db_file" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1081" name="program_file" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1082" name="program" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1083" name="module_version" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1084" name="analysis_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1085" name="db_version" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1086" name="gff_source" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1087" name="parameters" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1088" name="db" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1089" columnIds="1084" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="66" id="1090" name="associated_xref" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1091" name="source_xref_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1092" name="object_xref_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1093" name="condition_type" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1094" name="rank" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1095" name="xref_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1096" name="associated_xref_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1097" name="associated_group_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1098" columnIds="1096" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1099" columnIds="1097" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1100" columnIds="1092" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1101" columnIds="1095" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="71" id="1102" name="external_feature_file" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1103" name="feature_type_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1104" name="name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1105" name="epigenome_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1106" name="external_feature_file_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1107" name="analysis_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1108" columnIds="1106" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1109" columnIds="1103" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1110" columnIds="1105" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1111" columnIds="1107" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="106" id="1112" name="regulatory_build_statistic" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1113" name="statistic" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1114" name="regulatory_build_statistic_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1115" name="value" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1116" name="regulatory_build_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1117" columnIds="1114" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1118" columnIds="1116" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="85" id="1119" name="binding_matrix_transcription_factor_complex" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1120" name="binding_matrix_transcription_factor_complex_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1121" name="binding_matrix_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1122" name="transcription_factor_complex_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1123" columnIds="1120" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1124" columnIds="1122" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1125" columnIds="1121" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="28" id="1126" name="meta" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1127" name="species_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1128" name="meta_value" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1129" name="meta_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1130" name="meta_key" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1131" columnIds="1129" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="91" id="1132" name="idr" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1133" name="idr_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1134" name="failed_idr_pairs" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1135" name="experiment_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1136" name="type" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1137" name="max_peaks" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1138" columnIds="1133" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1139" columnIds="1135" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="20" id="1140" name="external_db" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1141" name="secondary_db_table" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1142" name="db_name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1143" name="db_release" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1144" name="external_db_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1145" name="db_display_name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1146" name="description" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1147" name="secondary_db_name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1148" name="priority" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1149" name="type" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1150" name="dbprimary_acc_linkable" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1151" name="status" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1152" columnIds="1144" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="93" id="1153" name="motif_feature_regulatory_feature" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1154" name="motif_feature_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1155" name="regulatory_feature_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1156" name="motif_feature_regulatory_feature_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1157" name="epigenome_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1158" name="has_matching_Peak" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1159" columnIds="1156" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1160" columnIds="1155" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1161" columnIds="1154" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1162" columnIds="1157" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="81" id="1163" name="alignment" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1164" name="bam_file_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1165" name="experiment_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1166" name="deduplicated_alignment_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1167" name="name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1168" name="has_duplicates" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1169" name="bigwig_file_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1170" name="is_complete" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1171" name="is_control" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1172" name="alignment_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1173" name="analysis_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1174" name="source_alignment_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1175" name="to_gender" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1176" columnIds="1172" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1177" columnIds="1165" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1178" columnIds="1173" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="95" id="1179" name="peak_calling" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1180" name="display_label" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1181" name="error_message" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1182" name="run_failed" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1183" name="peak_calling_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1184" name="experiment_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1185" name="feature_type_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1186" name="control_alignment_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1187" name="name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1188" name="signal_alignment_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1189" name="epigenome_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1190" name="analysis_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1191" columnIds="1183" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1192" columnIds="1184" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1193" columnIds="1190" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1194" columnIds="1189" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1195" columnIds="1185" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="5" id="1196" name="array_chip" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1197" name="array_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1198" name="design_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1199" name="name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1200" name="array_chip_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1201" columnIds="1200" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1202" columnIds="1197" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="90" id="1203" name="frip" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1204" name="total_reads" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1205" name="frip" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1206" name="peak_calling_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1207" name="frip_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1208" columnIds="1207" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1209" columnIds="1206" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="98" id="1210" name="probe_feature_transcript" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1211" name="probe_feature_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1212" name="stable_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1213" name="probe_feature_transcript_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1214" name="description" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1215" columnIds="1213" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1216" columnIds="1211" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="101" id="1217" name="probe_seq" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1218" name="sequence" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1219" name="probe_seq_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1220" name="sequence_upper" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1221" name="sequence_upper_sha1" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1222" columnIds="1219" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="34" id="1223" name="probe_set" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1224" name="probe_set_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1225" name="size" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1226" name="name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1227" name="array_chip_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1228" name="family" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1229" columnIds="1224" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1230" columnIds="1227" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="4" id="1231" name="array" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1232" name="array_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1233" name="has_sense_interrogation" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1234" name="vendor" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1235" name="name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1236" name="format" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1237" name="description" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1238" name="type" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1239" name="is_probeset_array" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1240" name="class" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1241" name="is_linked_array" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1242" columnIds="1232" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="54" id="1243" name="binding_matrix" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1244" name="stable_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1245" name="binding_matrix_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1246" name="name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1247" name="threshold" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1248" name="source" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1249" columnIds="1245" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="107" id="1250" name="segmentation" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1251" name="segmentation_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1252" name="superclass" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1253" name="name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1254" name="class" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1255" name="regulatory_build_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1256" columnIds="1251" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1257" columnIds="1255" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="112" id="1258" name="transcription_factor" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1259" name="transcription_factor_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1260" name="feature_type_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1261" name="name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1262" name="gene_stable_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1263" columnIds="1259" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1264" columnIds="1260" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="68" id="1265" name="mirna_target_feature" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1266" name="evidence" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1267" name="method" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1268" name="seq_region_end" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1269" name="accession" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1270" name="mirna_target_feature_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1271" name="display_label" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1272" name="seq_region_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1273" name="feature_set_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1274" name="interdb_stable_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1275" name="feature_type_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1276" name="supporting_information" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1277" name="seq_region_strand" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1278" name="seq_region_start" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1279" columnIds="1270" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1280" columnIds="1275" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1281" columnIds="1273" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="96" id="1282" name="peak_calling_statistic" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1283" name="statistic" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1284" name="peak_calling_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1285" name="feature_type_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1286" name="epigenome_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1287" name="peak_calling_statistic_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1288" name="value" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1289" columnIds="1287" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1290" columnIds="1284" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1291" columnIds="1286" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1292" columnIds="1285" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="21" id="1293" name="external_feature" ignore="true" inSchemaPartition="funcgen_species_list">
+			<column id="1294" name="display_label" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1295" name="seq_region_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1296" name="external_feature_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1297" name="interdb_stable_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1298" name="feature_set_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1299" name="feature_type_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1300" name="seq_region_strand" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1301" name="seq_region_end" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1302" name="seq_region_start" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1303" columnIds="1296" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1304" columnIds="1299" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1305" columnIds="1298" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="36" id="1306" name="regulatory_feature" ignore="true" inSchemaPartition="funcgen_species_list">
+			<column id="1307" name="bound_end_length" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1308" name="stable_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1309" name="seq_region_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1310" name="bound_start_length" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1311" name="regulatory_feature_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1312" name="feature_type_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1313" name="seq_region_strand" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1314" name="epigenome_count" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1315" name="seq_region_end" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1316" name="regulatory_build_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1317" name="seq_region_start" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1318" columnIds="1311" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1319" columnIds="1312" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1320" columnIds="1316" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="45" id="1321" name="unmapped_reason" ignore="true" inSchemaPartition="funcgen_species_list">
+			<column id="1322" name="full_description" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1323" name="unmapped_reason_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1324" name="summary_description" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1325" columnIds="1323" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="84" id="1326" name="binding_matrix_frequencies" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1327" name="binding_matrix_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1328" name="nucleotide" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1329" name="binding_matrix_frequencies_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1330" name="position" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1331" name="frequency" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1332" columnIds="1329" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1333" columnIds="1327" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="55" id="1334" name="motif_feature" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1335" name="score" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1336" name="stable_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1337" name="seq_region_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1338" name="binding_matrix_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1339" name="motif_feature_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1340" name="seq_region_strand" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1341" name="seq_region_end" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1342" name="seq_region_start" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1343" columnIds="1339" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1344" columnIds="1338" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="69" id="1345" name="epigenome" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1346" name="display_label" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1347" name="gender" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1348" name="production_name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1349" name="name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1350" name="description" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1351" name="epigenome_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1352" columnIds="1351" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="86" id="1353" name="chance" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1354" name="error_message" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1355" name="chance_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1356" name="control_enrichment_stronger_than_chip_at_bin" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1357" name="differential_percentage_enrichment" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1358" name="control_alignment_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1359" name="analysis_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1360" name="pcr_amplification_bias_in_Input_coverage_of_1_percent_of_genome" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1361" name="p" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1362" name="q" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1363" name="divergence" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1364" name="input_scaling_factor" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1365" name="path" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1366" name="run_failed" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1367" name="first_nonzero_bin_at" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1368" name="z_score" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1369" name="percent_genome_enriched" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1370" name="signal_alignment_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1371" columnIds="1355" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1372" columnIds="1359" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="22" id="1373" name="external_synonym" ignore="true" inSchemaPartition="funcgen_species_list">
+			<column id="1374" name="synonym" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1375" name="xref_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1376" columnIds="1375,1374" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1377" columnIds="1375" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="111" id="1378" name="segmentation_statistic" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1379" name="segmentation_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1380" name="statistic" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1381" name="segmentation_statistic_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1382" name="state" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1383" name="label" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1384" name="epigenome_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1385" name="value" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1386" columnIds="1381" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1387" columnIds="1379" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1388" columnIds="1384" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="65" id="1389" name="associated_group" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1390" name="description" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1391" name="associated_group_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1392" columnIds="1391" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="2" id="1393" name="analysis_description" ignore="true" inSchemaPartition="funcgen_species_list">
+			<column id="1394" name="display_label" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1395" name="web_data" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1396" name="displayable" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1397" name="description" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1398" name="analysis_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<foreignKey id="1399" columnIds="1398" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="94" id="1400" name="peak" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1401" name="score" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1402" name="seq_region_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1403" name="peak_calling_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1404" name="peak_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1405" name="seq_region_strand" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1406" name="seq_region_end" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1407" name="summit" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1408" name="seq_region_start" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1409" columnIds="1404" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1410" columnIds="1403" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="115" id="1411" name="underlying_structure" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1412" name="motif_feature_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1413" name="regulatory_feature_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1414" name="underlying_structure_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1415" columnIds="1414" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1416" columnIds="1413" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1417" columnIds="1412" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="31" id="1418" name="probe" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1419" name="probe_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1420" name="probe_set_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1421" name="name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1422" name="length" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1423" name="probe_seq_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1424" name="description" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1425" name="array_chip_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1426" name="class" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1427" columnIds="1419" status="HANDMADE" visibleModified="false"/>
+			<foreignKey id="1428" columnIds="1425" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1429" columnIds="1420" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1430" columnIds="1423" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="74" id="1431" name="regulatory_build_epigenome" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1432" name="regulatory_build_epigenome_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1433" name="epigenome_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1434" name="regulatory_build_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1435" columnIds="1432" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1436" columnIds="1433" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1437" columnIds="1434" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="24" id="1438" name="feature_type" ignore="true" inSchemaPartition="funcgen_species_list">
+			<column id="1439" name="feature_type_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1440" name="production_name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1441" name="so_accession" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1442" name="name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1443" name="description" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1444" name="so_name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1445" name="class" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1446" name="analysis_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1447" columnIds="1439" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1448" columnIds="1446" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="92" id="1449" name="motif_feature_peak" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1450" name="motif_feature_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1451" name="peak_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1452" name="motif_feature_peak_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1453" columnIds="1452" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1454" columnIds="1450" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1455" columnIds="1451" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="26" id="1456" name="identity_xref" ignore="true" inSchemaPartition="funcgen_species_list">
+			<column id="1457" name="xref_end" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1458" name="ensembl_identity" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1459" name="score" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1460" name="xref_start" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1461" name="cigar_line" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1462" name="xref_identity" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1463" name="ensembl_start" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1464" name="ensembl_end" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1465" name="object_xref_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1466" name="evalue" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1467" columnIds="1465" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1468" columnIds="1465" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="89" id="1469" name="fastqc" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1470" name="per_base_n_content" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1471" name="error_message" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1472" name="sequence_length_distribution" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1473" name="per_sequence_quality_scores" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1474" name="sequence_duplication_levels" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1475" name="read_file_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1476" name="per_tile_sequence_quality" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1477" name="basic_statistics" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1478" name="kmer_content" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1479" name="run_failed" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1480" name="per_base_sequence_quality" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1481" name="per_sequence_gc_content" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1482" name="overrepresented_sequences" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1483" name="fastqc_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1484" name="adapter_content" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1485" name="per_base_sequence_content" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1486" columnIds="1483" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1487" columnIds="1475" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="29" id="1488" name="meta_coord" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1489" name="coord_system_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1490" name="table_name" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1491" name="max_length" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+		</table>
+		<table uniqueId="97" id="1492" name="phantom_peak" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1493" name="error_message" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1494" name="rsc" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1495" name="analysis_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1496" name="alignment_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1497" name="num_reads" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1498" name="corr_est_frag_len" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1499" name="phantom_peak_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1500" name="est_frag_len_3" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1501" name="est_frag_len_2" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1502" name="run_failed" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1503" name="corr_phantom_peak" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1504" name="corr_est_frag_len_2" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1505" name="min_corr" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1506" name="phantom_peak" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1507" name="est_frag_len" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1508" name="corr_est_frag_len_3" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1509" name="quality_tag" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1510" name="argmin_corr" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1511" name="nsc" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1512" columnIds="1499" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1513" columnIds="1495" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1514" columnIds="1496" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="72" id="1515" name="regulatory_activity" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1516" name="regulatory_feature_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1517" name="regulatory_activity_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1518" name="activity" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1519" name="epigenome_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1520" columnIds="1517" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1521" columnIds="1519" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1522" columnIds="1516" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="30" id="1523" name="object_xref" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1524" name="linkage_annotation" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1525" name="object_xref_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1526" name="ensembl_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1527" name="xref_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1528" name="ensembl_object_type" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1529" name="analysis_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1530" columnIds="1525" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1531" columnIds="1529" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1532" columnIds="1527" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1533" columnIds="1526" status="HANDMADE" visibleModified="false"/>
+		</table>
+		<table uniqueId="53" id="1534" name="associated_motif_feature" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1535" name="motif_feature_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1536" name="annotated_feature_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1537" columnIds="1536,1535" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1538" columnIds="1535" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="114" id="1539" name="transcription_factor_complex_composition" ignore="false" inSchemaPartition="funcgen_species_list">
+			<column id="1540" name="transcription_factor_complex_composition_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1541" name="transcription_factor_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<column id="1542" name="transcription_factor_complex_id" visibleModified="false" inSchemaPartition="funcgen_species_list"/>
+			<primaryKey id="1543" columnIds="1540" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1544" columnIds="1542" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1545" columnIds="1541" status="INFERRED" visibleModified="false"/>
+		</table>
+		<relation id="1546" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1447" secondKeyId="1060" status="INFERRED" visibleModified="false"/>
+		<relation id="1547" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1089" secondKeyId="1002" status="INFERRED" visibleModified="false"/>
+		<relation id="1548" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1447" secondKeyId="1292" status="INFERRED" visibleModified="false"/>
+		<relation id="1549" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="971" secondKeyId="934" status="INFERRED" visibleModified="false"/>
+		<relation id="1550" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1089" secondKeyId="1531" status="INFERRED" visibleModified="false"/>
+		<relation id="1551" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="899" secondKeyId="1073" status="INFERRED" visibleModified="false"/>
+		<relation id="1552" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1013" secondKeyId="1101" status="INFERRED" visibleModified="false"/>
+		<relation id="1553" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1318" secondKeyId="1522" status="INFERRED" visibleModified="false"/>
+		<relation id="1554" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1352" secondKeyId="902" status="INFERRED" visibleModified="false"/>
+		<relation id="1555" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1176" secondKeyId="935" status="INFERRED" visibleModified="false"/>
+		<relation id="1556" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1343" secondKeyId="1454" status="INFERRED" visibleModified="false"/>
+		<relation id="1557" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1152" secondKeyId="1014" status="INFERRED" visibleModified="false"/>
+		<relation id="1558" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1089" secondKeyId="1178" status="INFERRED" visibleModified="false"/>
+		<relation id="1559" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="971" secondKeyId="1487" status="INFERRED" visibleModified="false"/>
+		<relation id="1560" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1089" secondKeyId="1448" status="INFERRED" visibleModified="false"/>
+		<relation id="1561" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1013" secondKeyId="1377" status="INFERRED" visibleModified="false"/>
+		<relation id="1562" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="911" secondKeyId="1281" status="INFERRED" visibleModified="false"/>
+		<relation id="1563" cardinality="M(b)" originalCardinality="M(b)" firstKeyId="1533" secondKeyId="1229" status="HANDMADE" visibleModified="false"/>
+		<relation id="1564" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1229" secondKeyId="1429" status="INFERRED" visibleModified="false"/>
+		<relation id="1565" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1352" secondKeyId="1194" status="INFERRED" visibleModified="false"/>
+		<relation id="1566" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1152" secondKeyId="888" status="INFERRED" visibleModified="false"/>
+		<relation id="1567" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1447" secondKeyId="901" status="INFERRED" visibleModified="false"/>
+		<relation id="1568" cardinality="M(b)" originalCardinality="M(b)" firstKeyId="1533" secondKeyId="1427" status="HANDMADE" visibleModified="false"/>
+		<relation id="1569" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1256" secondKeyId="989" status="INFERRED" visibleModified="false"/>
+		<relation id="1570" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1352" secondKeyId="1388" status="INFERRED" visibleModified="false"/>
+		<relation id="1571" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="840" secondKeyId="1544" status="INFERRED" visibleModified="false"/>
+		<relation id="1572" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1191" secondKeyId="1410" status="INFERRED" visibleModified="false"/>
+		<relation id="1573" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1447" secondKeyId="1264" status="INFERRED" visibleModified="false"/>
+		<relation id="1574" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1176" secondKeyId="1514" status="INFERRED" visibleModified="false"/>
+		<relation id="1575" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1089" secondKeyId="1111" status="INFERRED" visibleModified="false"/>
+		<relation id="1576" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="853" secondKeyId="1257" status="INFERRED" visibleModified="false"/>
+		<relation id="1577" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1352" secondKeyId="990" status="INFERRED" visibleModified="false"/>
+		<relation id="1578" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="899" secondKeyId="1139" status="INFERRED" visibleModified="false"/>
+		<relation id="1579" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1089" secondKeyId="834" status="INFERRED" visibleModified="false"/>
+		<relation id="1580" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1249" secondKeyId="1125" status="INFERRED" visibleModified="false"/>
+		<relation id="1581" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1013" secondKeyId="1532" status="INFERRED" visibleModified="false"/>
+		<relation id="1582" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1325" secondKeyId="887" status="INFERRED" visibleModified="false"/>
+		<relation id="1583" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="853" secondKeyId="1118" status="INFERRED" visibleModified="false"/>
+		<relation id="1584" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1089" secondKeyId="913" status="INFERRED" visibleModified="false"/>
+		<relation id="1585" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1352" secondKeyId="1110" status="INFERRED" visibleModified="false"/>
+		<relation id="1586" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1201" secondKeyId="1230" status="INFERRED" visibleModified="false"/>
+		<relation id="1587" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1191" secondKeyId="1290" status="INFERRED" visibleModified="false"/>
+		<relation id="1588" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="833" secondKeyId="1216" status="INFERRED" visibleModified="false"/>
+		<relation id="1589" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1256" secondKeyId="1039" status="INFERRED" visibleModified="false"/>
+		<relation id="1590" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1343" secondKeyId="1538" status="INFERRED" visibleModified="false"/>
+		<relation id="1591" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1089" secondKeyId="972" status="INFERRED" visibleModified="false"/>
+		<relation id="1592" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1447" secondKeyId="854" status="INFERRED" visibleModified="false"/>
+		<relation id="1593" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1427" secondKeyId="920" status="INFERRED" visibleModified="false"/>
+		<relation id="1594" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="853" secondKeyId="1320" status="INFERRED" visibleModified="false"/>
+		<relation id="1595" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1222" secondKeyId="1430" status="INFERRED" visibleModified="false"/>
+		<relation id="1596" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1263" secondKeyId="1545" status="INFERRED" visibleModified="false"/>
+		<relation id="1597" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="911" secondKeyId="1305" status="INFERRED" visibleModified="false"/>
+		<relation id="1598" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1242" secondKeyId="1202" status="INFERRED" visibleModified="false"/>
+		<relation id="1599" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="853" secondKeyId="1437" status="INFERRED" visibleModified="false"/>
+		<relation id="1600" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1447" secondKeyId="1319" status="INFERRED" visibleModified="false"/>
+		<relation id="1601" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1229" secondKeyId="1027" status="INFERRED" visibleModified="false"/>
+		<relation id="1602" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="853" secondKeyId="1038" status="INFERRED" visibleModified="false"/>
+		<relation id="1603" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1201" secondKeyId="1428" status="INFERRED" visibleModified="false"/>
+		<relation id="1604" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1447" secondKeyId="912" status="INFERRED" visibleModified="false"/>
+		<relation id="1605" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1530" secondKeyId="1468" status="INFERRED" visibleModified="false"/>
+		<relation id="1606" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1249" secondKeyId="1333" status="INFERRED" visibleModified="false"/>
+		<relation id="1607" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1352" secondKeyId="1036" status="INFERRED" visibleModified="false"/>
+		<relation id="1608" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1409" secondKeyId="1455" status="INFERRED" visibleModified="false"/>
+		<relation id="1609" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1318" secondKeyId="1160" status="INFERRED" visibleModified="false"/>
+		<relation id="1610" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1249" secondKeyId="1344" status="INFERRED" visibleModified="false"/>
+		<relation id="1611" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1089" secondKeyId="1372" status="INFERRED" visibleModified="false"/>
+		<relation id="1612" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1343" secondKeyId="1161" status="INFERRED" visibleModified="false"/>
+		<relation id="1613" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1242" secondKeyId="953" status="INFERRED" visibleModified="false"/>
+		<relation id="1614" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="899" secondKeyId="945" status="INFERRED" visibleModified="false"/>
+		<relation id="1615" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1447" secondKeyId="1109" status="INFERRED" visibleModified="false"/>
+		<relation id="1616" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1089" secondKeyId="1193" status="INFERRED" visibleModified="false"/>
+		<relation id="1617" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1530" secondKeyId="1020" status="INFERRED" visibleModified="false"/>
+		<relation id="1618" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="899" secondKeyId="1177" status="INFERRED" visibleModified="false"/>
+		<relation id="1619" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1089" secondKeyId="889" status="INFERRED" visibleModified="false"/>
+		<relation id="1620" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="899" secondKeyId="1192" status="INFERRED" visibleModified="false"/>
+		<relation id="1621" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="971" secondKeyId="946" status="INFERRED" visibleModified="false"/>
+		<relation id="1622" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1447" secondKeyId="1280" status="INFERRED" visibleModified="false"/>
+		<relation id="1623" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1089" secondKeyId="1399" status="INFERRED" visibleModified="false"/>
+		<relation id="1624" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="928" secondKeyId="900" status="INFERRED" visibleModified="false"/>
+		<relation id="1625" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1318" secondKeyId="1416" status="INFERRED" visibleModified="false"/>
+		<relation id="1626" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1089" secondKeyId="1037" status="INFERRED" visibleModified="false"/>
+		<relation id="1627" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1530" secondKeyId="1100" status="INFERRED" visibleModified="false"/>
+		<relation id="1628" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1352" secondKeyId="1291" status="INFERRED" visibleModified="false"/>
+		<relation id="1629" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1447" secondKeyId="991" status="INFERRED" visibleModified="false"/>
+		<relation id="1630" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1520" secondKeyId="1066" status="INFERRED" visibleModified="false"/>
+		<relation id="1631" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1447" secondKeyId="1304" status="INFERRED" visibleModified="false"/>
+		<relation id="1632" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1089" secondKeyId="1513" status="INFERRED" visibleModified="false"/>
+		<relation id="1633" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="840" secondKeyId="1124" status="INFERRED" visibleModified="false"/>
+		<relation id="1634" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1392" secondKeyId="1099" status="INFERRED" visibleModified="false"/>
+		<relation id="1635" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1176" secondKeyId="1003" status="INFERRED" visibleModified="false"/>
+		<relation id="1636" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1191" secondKeyId="1209" status="INFERRED" visibleModified="false"/>
+		<relation id="1637" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1343" secondKeyId="1417" status="INFERRED" visibleModified="false"/>
+		<relation id="1638" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1089" secondKeyId="855" status="INFERRED" visibleModified="false"/>
+		<relation id="1639" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1427" secondKeyId="835" status="INFERRED" visibleModified="false"/>
+		<relation id="1640" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1352" secondKeyId="1436" status="INFERRED" visibleModified="false"/>
+		<relation id="1641" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1447" secondKeyId="1195" status="INFERRED" visibleModified="false"/>
+		<relation id="1642" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1256" secondKeyId="1387" status="INFERRED" visibleModified="false"/>
+		<relation id="1643" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1352" secondKeyId="1162" status="INFERRED" visibleModified="false"/>
+		<relation id="1644" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1352" secondKeyId="1521" status="INFERRED" visibleModified="false"/>
+	</jdbcSchema>
+	<jdbcSchema uniqueId="10" driverClassName="com.mysql.jdbc.Driver" url="jdbc:mysql://%HOST%:%PORT%/ensembl_ontology_%ENS%" databaseName="ensembl_ontology_%ENS%" schemaName="ensembl_ontology_%ENS%" username="%USER%" password="%PASS%" name="ontology" keyguessing="true" masked="false" hideMasked="true">
+		<table uniqueId="126" id="1645" name="aux_TO_Solanaceae_spp_map" ignore="false">
+			<column id="1646" name="subset_term_id" visibleModified="false"/>
+			<column id="1647" name="distance" visibleModified="false"/>
+			<column id="1648" name="term_id" visibleModified="false"/>
+			<foreignKey id="1649" columnIds="1648" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="124" id="1650" name="aux_TO_Hordeum_vulgare_map" ignore="false">
+			<column id="1651" name="subset_term_id" visibleModified="false"/>
+			<column id="1652" name="distance" visibleModified="false"/>
+			<column id="1653" name="term_id" visibleModified="false"/>
+			<foreignKey id="1654" columnIds="1653" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="98" id="1655" name="aux_PATO_attribute_slim_map" ignore="false">
+			<column id="1656" name="subset_term_id" visibleModified="false"/>
+			<column id="1657" name="distance" visibleModified="false"/>
+			<column id="1658" name="term_id" visibleModified="false"/>
+			<foreignKey id="1659" columnIds="1658" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="120" id="1660" name="aux_PO_TraitNet_map" ignore="false">
+			<column id="1661" name="subset_term_id" visibleModified="false"/>
+			<column id="1662" name="distance" visibleModified="false"/>
+			<column id="1663" name="term_id" visibleModified="false"/>
+			<foreignKey id="1664" columnIds="1663" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="109" id="1665" name="aux_PO_Bryophytes_map" ignore="false">
+			<column id="1666" name="subset_term_id" visibleModified="false"/>
+			<column id="1667" name="distance" visibleModified="false"/>
+			<column id="1668" name="term_id" visibleModified="false"/>
+			<foreignKey id="1669" columnIds="1668" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="4" id="1670" name="relation" ignore="true">
+			<column id="1671" name="ontology_id" visibleModified="false"/>
+			<column id="1672" name="relation_type_id" visibleModified="false"/>
+			<column id="1673" name="parent_term_id" visibleModified="false"/>
+			<column id="1674" name="intersection_of" visibleModified="false"/>
+			<column id="1675" name="child_term_id" visibleModified="false"/>
+			<column id="1676" name="relation_id" visibleModified="false"/>
+			<primaryKey id="1677" columnIds="1676" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1678" columnIds="1672" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1679" columnIds="1671" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="24" id="1680" name="aux_GO_goslim_metagenomics_map" ignore="true">
+			<column id="1681" name="subset_term_id" visibleModified="false"/>
+			<column id="1682" name="distance" visibleModified="false"/>
+			<column id="1683" name="term_id" visibleModified="false"/>
+			<foreignKey id="1684" columnIds="1683" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="99" id="1685" name="aux_PATO_cell_quality_map" ignore="false">
+			<column id="1686" name="subset_term_id" visibleModified="false"/>
+			<column id="1687" name="distance" visibleModified="false"/>
+			<column id="1688" name="term_id" visibleModified="false"/>
+			<foreignKey id="1689" columnIds="1688" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="111" id="1690" name="aux_PO_Citrus_map" ignore="false">
+			<column id="1691" name="subset_term_id" visibleModified="false"/>
+			<column id="1692" name="distance" visibleModified="false"/>
+			<column id="1693" name="term_id" visibleModified="false"/>
+			<foreignKey id="1694" columnIds="1693" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="139" id="1695" name="aux_GO_goslim_agr_map" ignore="false">
+			<column id="1696" name="subset_term_id" visibleModified="false"/>
+			<column id="1697" name="distance" visibleModified="false"/>
+			<column id="1698" name="term_id" visibleModified="false"/>
+			<foreignKey id="1699" columnIds="1698" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="13" id="1700" name="aux_GO_goslim_yeast_map" ignore="true">
+			<column id="1701" name="subset_term_id" visibleModified="false"/>
+			<column id="1702" name="distance" visibleModified="false"/>
+			<column id="1703" name="term_id" visibleModified="false"/>
+			<foreignKey id="1704" columnIds="1703" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="119" id="1705" name="aux_PO_Tomato_map" ignore="false">
+			<column id="1706" name="subset_term_id" visibleModified="false"/>
+			<column id="1707" name="distance" visibleModified="false"/>
+			<column id="1708" name="term_id" visibleModified="false"/>
+			<foreignKey id="1709" columnIds="1708" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="103" id="1710" name="aux_PATO_relational_slim_map" ignore="false">
+			<column id="1711" name="subset_term_id" visibleModified="false"/>
+			<column id="1712" name="distance" visibleModified="false"/>
+			<column id="1713" name="term_id" visibleModified="false"/>
+			<foreignKey id="1714" columnIds="1713" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="61" id="1715" name="aux_MP_CvDC_Terms_map" ignore="true">
+			<column id="1716" name="subset_term_id" visibleModified="false"/>
+			<column id="1717" name="distance" visibleModified="false"/>
+			<column id="1718" name="term_id" visibleModified="false"/>
+			<foreignKey id="1719" columnIds="1718" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="137" id="1720" name="aux_FYPO_qc_do_not_manually_annotate_map" ignore="false">
+			<column id="1721" name="subset_term_id" visibleModified="false"/>
+			<column id="1722" name="distance" visibleModified="false"/>
+			<column id="1723" name="term_id" visibleModified="false"/>
+			<foreignKey id="1724" columnIds="1723" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="156" id="1725" name="aux_MONDO_ordo_clinical_subtype_map" ignore="false">
+			<column id="1726" name="subset_term_id" visibleModified="false"/>
+			<column id="1727" name="distance" visibleModified="false"/>
+			<column id="1728" name="term_id" visibleModified="false"/>
+			<foreignKey id="1729" columnIds="1728" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="62" id="1730" name="aux_MP_Europhenome_Terms_map" ignore="true">
+			<column id="1731" name="subset_term_id" visibleModified="false"/>
+			<column id="1732" name="distance" visibleModified="false"/>
+			<column id="1733" name="term_id" visibleModified="false"/>
+			<foreignKey id="1734" columnIds="1733" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="2" id="1735" name="meta" ignore="false">
+			<column id="1736" name="species_id" visibleModified="false"/>
+			<column id="1737" name="meta_value" visibleModified="false"/>
+			<column id="1738" name="meta_id" visibleModified="false"/>
+			<column id="1739" name="meta_key" visibleModified="false"/>
+			<primaryKey id="1740" columnIds="1738" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="129" id="1741" name="aux_UO_prefix_slim_map" ignore="false">
+			<column id="1742" name="subset_term_id" visibleModified="false"/>
+			<column id="1743" name="distance" visibleModified="false"/>
+			<column id="1744" name="term_id" visibleModified="false"/>
+			<foreignKey id="1745" columnIds="1744" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="154" id="1746" name="aux_MONDO_ordo_biological_anomaly_map" ignore="false">
+			<column id="1747" name="subset_term_id" visibleModified="false"/>
+			<column id="1748" name="distance" visibleModified="false"/>
+			<column id="1749" name="term_id" visibleModified="false"/>
+			<foreignKey id="1750" columnIds="1749" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="110" id="1751" name="aux_PO_CL_map" ignore="false">
+			<column id="1752" name="subset_term_id" visibleModified="false"/>
+			<column id="1753" name="distance" visibleModified="false"/>
+			<column id="1754" name="term_id" visibleModified="false"/>
+			<foreignKey id="1755" columnIds="1754" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="7" id="1756" name="aux_GO_goslim_candida_map" ignore="true">
+			<column id="1757" name="subset_term_id" visibleModified="false"/>
+			<column id="1758" name="distance" visibleModified="false"/>
+			<column id="1759" name="term_id" visibleModified="false"/>
+			<foreignKey id="1760" columnIds="1759" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="159" id="1761" name="aux_MONDO_ordo_etiological_subtype_map" ignore="false">
+			<column id="1762" name="subset_term_id" visibleModified="false"/>
+			<column id="1763" name="distance" visibleModified="false"/>
+			<column id="1764" name="term_id" visibleModified="false"/>
+			<foreignKey id="1765" columnIds="1764" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="166" id="1766" name="aux_MONDO_predisposition_map" ignore="false">
+			<column id="1767" name="subset_term_id" visibleModified="false"/>
+			<column id="1768" name="distance" visibleModified="false"/>
+			<column id="1769" name="term_id" visibleModified="false"/>
+			<foreignKey id="1770" columnIds="1769" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="161" id="1771" name="aux_MONDO_ordo_histopathological_subtype_map" ignore="false">
+			<column id="1772" name="subset_term_id" visibleModified="false"/>
+			<column id="1773" name="distance" visibleModified="false"/>
+			<column id="1774" name="term_id" visibleModified="false"/>
+			<foreignKey id="1775" columnIds="1774" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="138" id="1776" name="aux_GO_goslim_ChEMBL_map" ignore="false">
+			<column id="1777" name="subset_term_id" visibleModified="false"/>
+			<column id="1778" name="distance" visibleModified="false"/>
+			<column id="1779" name="term_id" visibleModified="false"/>
+			<foreignKey id="1780" columnIds="1779" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="22" id="1781" name="aux_GO_goslim_aspergillus_map" ignore="true">
+			<column id="1782" name="subset_term_id" visibleModified="false"/>
+			<column id="1783" name="distance" visibleModified="false"/>
+			<column id="1784" name="term_id" visibleModified="false"/>
+			<foreignKey id="1785" columnIds="1784" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="125" id="1786" name="aux_TO_Saccharum_map" ignore="false">
+			<column id="1787" name="subset_term_id" visibleModified="false"/>
+			<column id="1788" name="distance" visibleModified="false"/>
+			<column id="1789" name="term_id" visibleModified="false"/>
+			<foreignKey id="1790" columnIds="1789" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="68" id="1791" name="aux_ECO_valid_with_biological_process_map" ignore="false">
+			<column id="1792" name="subset_term_id" visibleModified="false"/>
+			<column id="1793" name="distance" visibleModified="false"/>
+			<column id="1794" name="term_id" visibleModified="false"/>
+			<foreignKey id="1795" columnIds="1794" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="108" id="1796" name="aux_PO_Arabidopsis_map" ignore="false">
+			<column id="1797" name="subset_term_id" visibleModified="false"/>
+			<column id="1798" name="distance" visibleModified="false"/>
+			<column id="1799" name="term_id" visibleModified="false"/>
+			<foreignKey id="1800" columnIds="1799" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="70" id="1801" name="aux_ECO_valid_with_chemical_entity_map" ignore="false">
+			<column id="1802" name="subset_term_id" visibleModified="false"/>
+			<column id="1803" name="distance" visibleModified="false"/>
+			<column id="1804" name="term_id" visibleModified="false"/>
+			<foreignKey id="1805" columnIds="1804" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="6" id="1806" name="term" ignore="false">
+			<column id="1807" name="ontology_id" visibleModified="false"/>
+			<column id="1808" name="iri" visibleModified="false"/>
+			<column id="1809" name="name" visibleModified="false"/>
+			<column id="1810" name="definition" visibleModified="false"/>
+			<column id="1811" name="term_id" visibleModified="false"/>
+			<column id="1812" name="accession" visibleModified="false"/>
+			<column id="1813" name="is_root" visibleModified="false"/>
+			<column id="1814" name="subsets" visibleModified="false"/>
+			<column id="1815" name="is_obsolete" visibleModified="false"/>
+			<primaryKey id="1816" columnIds="1811" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1817" columnIds="1807" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1818" columnIds="1812" status="HANDMADE" visibleModified="false"/>
+		</table>
+		<table uniqueId="16" id="1819" name="aux_SO_biosapiens_map" ignore="true">
+			<column id="1820" name="subset_term_id" visibleModified="false"/>
+			<column id="1821" name="distance" visibleModified="false"/>
+			<column id="1822" name="term_id" visibleModified="false"/>
+			<foreignKey id="1823" columnIds="1822" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="155" id="1824" name="aux_MONDO_ordo_clinical_situation_map" ignore="false">
+			<column id="1825" name="subset_term_id" visibleModified="false"/>
+			<column id="1826" name="distance" visibleModified="false"/>
+			<column id="1827" name="term_id" visibleModified="false"/>
+			<foreignKey id="1828" columnIds="1827" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="34" id="1829" name="aux_EFO_efo_slim_map" ignore="true">
+			<column id="1830" name="subset_term_id" visibleModified="false"/>
+			<column id="1831" name="distance" visibleModified="false"/>
+			<column id="1832" name="term_id" visibleModified="false"/>
+			<foreignKey id="1833" columnIds="1832" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="151" id="1834" name="aux_MONDO_mostly_harmless_map" ignore="false">
+			<column id="1835" name="subset_term_id" visibleModified="false"/>
+			<column id="1836" name="distance" visibleModified="false"/>
+			<column id="1837" name="term_id" visibleModified="false"/>
+			<foreignKey id="1838" columnIds="1837" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="142" id="1839" name="aux_HP_secondary_consequence_map" ignore="false">
+			<column id="1840" name="subset_term_id" visibleModified="false"/>
+			<column id="1841" name="distance" visibleModified="false"/>
+			<column id="1842" name="term_id" visibleModified="false"/>
+			<foreignKey id="1843" columnIds="1842" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="47" id="1844" name="aux_GO_goslim_synapse_map" ignore="true">
+			<column id="1845" name="subset_term_id" visibleModified="false"/>
+			<column id="1846" name="distance" visibleModified="false"/>
+			<column id="1847" name="term_id" visibleModified="false"/>
+			<foreignKey id="1848" columnIds="1847" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="35" id="1849" name="aux_EFO_functional_classification_map" ignore="true">
+			<column id="1850" name="subset_term_id" visibleModified="false"/>
+			<column id="1851" name="distance" visibleModified="false"/>
+			<column id="1852" name="term_id" visibleModified="false"/>
+			<foreignKey id="1853" columnIds="1852" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="162" id="1854" name="aux_MONDO_ordo_inheritance_inconsistent_map" ignore="false">
+			<column id="1855" name="subset_term_id" visibleModified="false"/>
+			<column id="1856" name="distance" visibleModified="false"/>
+			<column id="1857" name="term_id" visibleModified="false"/>
+			<foreignKey id="1858" columnIds="1857" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="74" id="1859" name="aux_ECO_valid_with_protein_map" ignore="false">
+			<column id="1860" name="subset_term_id" visibleModified="false"/>
+			<column id="1861" name="distance" visibleModified="false"/>
+			<column id="1862" name="term_id" visibleModified="false"/>
+			<foreignKey id="1863" columnIds="1862" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="135" id="1864" name="aux_CL__upper_level_map" ignore="false">
+			<column id="1865" name="subset_term_id" visibleModified="false"/>
+			<column id="1866" name="distance" visibleModified="false"/>
+			<column id="1867" name="term_id" visibleModified="false"/>
+			<foreignKey id="1868" columnIds="1867" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="8" id="1869" name="aux_GO_goslim_generic_map" ignore="true">
+			<column id="1870" name="subset_term_id" visibleModified="false"/>
+			<column id="1871" name="distance" visibleModified="false"/>
+			<column id="1872" name="term_id" visibleModified="false"/>
+			<foreignKey id="1873" columnIds="1872" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="36" id="1874" name="aux_EFO_grouping_class_map" ignore="true">
+			<column id="1875" name="subset_term_id" visibleModified="false"/>
+			<column id="1876" name="distance" visibleModified="false"/>
+			<column id="1877" name="term_id" visibleModified="false"/>
+			<foreignKey id="1878" columnIds="1877" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="64" id="1879" name="aux_MP_IMPC_map" ignore="true">
+			<column id="1880" name="subset_term_id" visibleModified="false"/>
+			<column id="1881" name="distance" visibleModified="false"/>
+			<column id="1882" name="term_id" visibleModified="false"/>
+			<foreignKey id="1883" columnIds="1882" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="149" id="1884" name="aux_MONDO_merged_class_map" ignore="false">
+			<column id="1885" name="subset_term_id" visibleModified="false"/>
+			<column id="1886" name="distance" visibleModified="false"/>
+			<column id="1887" name="term_id" visibleModified="false"/>
+			<foreignKey id="1888" columnIds="1887" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="168" id="1889" name="aux_MONDO_speculative_map" ignore="false">
+			<column id="1890" name="subset_term_id" visibleModified="false"/>
+			<column id="1891" name="distance" visibleModified="false"/>
+			<column id="1892" name="term_id" visibleModified="false"/>
+			<foreignKey id="1893" columnIds="1892" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="158" id="1894" name="aux_MONDO_ordo_disease_map" ignore="false">
+			<column id="1895" name="subset_term_id" visibleModified="false"/>
+			<column id="1896" name="distance" visibleModified="false"/>
+			<column id="1897" name="term_id" visibleModified="false"/>
+			<foreignKey id="1898" columnIds="1897" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="75" id="1899" name="aux_GO_goslim_mouse_map" ignore="false">
+			<column id="1900" name="subset_term_id" visibleModified="false"/>
+			<column id="1901" name="distance" visibleModified="false"/>
+			<column id="1902" name="term_id" visibleModified="false"/>
+			<foreignKey id="1903" columnIds="1902" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="143" id="1904" name="aux_MOD_PSI_MOD_slim_map" ignore="false">
+			<column id="1905" name="subset_term_id" visibleModified="false"/>
+			<column id="1906" name="distance" visibleModified="false"/>
+			<column id="1907" name="term_id" visibleModified="false"/>
+			<foreignKey id="1908" columnIds="1907" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="131" id="1909" name="aux_UO_unit_slim_map" ignore="false">
+			<column id="1910" name="subset_term_id" visibleModified="false"/>
+			<column id="1911" name="distance" visibleModified="false"/>
+			<column id="1912" name="term_id" visibleModified="false"/>
+			<foreignKey id="1913" columnIds="1912" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="5" id="1914" name="relation_type" ignore="true">
+			<column id="1915" name="relation_type_id" visibleModified="false"/>
+			<column id="1916" name="name" visibleModified="false"/>
+			<primaryKey id="1917" columnIds="1915" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="71" id="1918" name="aux_ECO_valid_with_gene_map" ignore="false">
+			<column id="1919" name="subset_term_id" visibleModified="false"/>
+			<column id="1920" name="distance" visibleModified="false"/>
+			<column id="1921" name="term_id" visibleModified="false"/>
+			<foreignKey id="1922" columnIds="1921" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="30" id="1923" name="aux_GO_gocheck_do_not_manually_annotate_map" ignore="true">
+			<column id="1924" name="subset_term_id" visibleModified="false"/>
+			<column id="1925" name="distance" visibleModified="false"/>
+			<column id="1926" name="term_id" visibleModified="false"/>
+			<foreignKey id="1927" columnIds="1926" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="39" id="1928" name="aux_EFO_major_organ_map" ignore="true">
+			<column id="1929" name="subset_term_id" visibleModified="false"/>
+			<column id="1930" name="distance" visibleModified="false"/>
+			<column id="1931" name="term_id" visibleModified="false"/>
+			<foreignKey id="1932" columnIds="1931" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="104" id="1933" name="aux_PATO_scalar_slim_map" ignore="false">
+			<column id="1934" name="subset_term_id" visibleModified="false"/>
+			<column id="1935" name="distance" visibleModified="false"/>
+			<column id="1936" name="term_id" visibleModified="false"/>
+			<foreignKey id="1937" columnIds="1936" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="42" id="1938" name="aux_EFO_vertebrate_core_map" ignore="true">
+			<column id="1939" name="subset_term_id" visibleModified="false"/>
+			<column id="1940" name="distance" visibleModified="false"/>
+			<column id="1941" name="term_id" visibleModified="false"/>
+			<foreignKey id="1942" columnIds="1941" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="69" id="1943" name="aux_ECO_valid_with_cellular_component_map" ignore="false">
+			<column id="1944" name="subset_term_id" visibleModified="false"/>
+			<column id="1945" name="distance" visibleModified="false"/>
+			<column id="1946" name="term_id" visibleModified="false"/>
+			<foreignKey id="1947" columnIds="1946" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="133" id="1948" name="aux_CHEBI_2_STAR_map" ignore="false">
+			<column id="1949" name="subset_term_id" visibleModified="false"/>
+			<column id="1950" name="distance" visibleModified="false"/>
+			<column id="1951" name="term_id" visibleModified="false"/>
+			<foreignKey id="1952" columnIds="1951" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="165" id="1953" name="aux_MONDO_other_hierarchy_map" ignore="false">
+			<column id="1954" name="subset_term_id" visibleModified="false"/>
+			<column id="1955" name="distance" visibleModified="false"/>
+			<column id="1956" name="term_id" visibleModified="false"/>
+			<foreignKey id="1957" columnIds="1956" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="101" id="1958" name="aux_PATO_hpo_slim_map" ignore="false">
+			<column id="1959" name="subset_term_id" visibleModified="false"/>
+			<column id="1960" name="distance" visibleModified="false"/>
+			<column id="1961" name="term_id" visibleModified="false"/>
+			<foreignKey id="1962" columnIds="1961" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="105" id="1963" name="aux_PATO_value_slim_map" ignore="false">
+			<column id="1964" name="subset_term_id" visibleModified="false"/>
+			<column id="1965" name="distance" visibleModified="false"/>
+			<column id="1966" name="term_id" visibleModified="false"/>
+			<foreignKey id="1967" columnIds="1966" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="116" id="1968" name="aux_PO_Potato_map" ignore="false">
+			<column id="1969" name="subset_term_id" visibleModified="false"/>
+			<column id="1970" name="distance" visibleModified="false"/>
+			<column id="1971" name="term_id" visibleModified="false"/>
+			<foreignKey id="1972" columnIds="1971" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="1" id="1973" name="closure" ignore="true">
+			<column id="1974" name="ontology_id" visibleModified="false"/>
+			<column id="1975" name="parent_term_id" visibleModified="false"/>
+			<column id="1976" name="distance" visibleModified="false"/>
+			<column id="1977" name="confident_relationship" visibleModified="false"/>
+			<column id="1978" name="subparent_term_id" visibleModified="false"/>
+			<column id="1979" name="child_term_id" visibleModified="false"/>
+			<column id="1980" name="closure_id" visibleModified="false"/>
+			<primaryKey id="1981" columnIds="1980" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="1982" columnIds="1974" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="3" id="1983" name="ontology" ignore="false">
+			<column id="1984" name="ontology_id" visibleModified="false"/>
+			<column id="1985" name="data_version" visibleModified="false"/>
+			<column id="1986" name="name" visibleModified="false"/>
+			<column id="1987" name="namespace" visibleModified="false"/>
+			<column id="1988" name="title" visibleModified="false"/>
+			<primaryKey id="1989" columnIds="1984" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="113" id="1990" name="aux_PO_Maize_map" ignore="false">
+			<column id="1991" name="subset_term_id" visibleModified="false"/>
+			<column id="1992" name="distance" visibleModified="false"/>
+			<column id="1993" name="term_id" visibleModified="false"/>
+			<foreignKey id="1994" columnIds="1993" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="115" id="1995" name="aux_PO_Poaceae_map" ignore="false">
+			<column id="1996" name="subset_term_id" visibleModified="false"/>
+			<column id="1997" name="distance" visibleModified="false"/>
+			<column id="1998" name="term_id" visibleModified="false"/>
+			<foreignKey id="1999" columnIds="1998" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="117" id="2000" name="aux_PO_Pteridophytes_map" ignore="false">
+			<column id="2001" name="subset_term_id" visibleModified="false"/>
+			<column id="2002" name="distance" visibleModified="false"/>
+			<column id="2003" name="term_id" visibleModified="false"/>
+			<foreignKey id="2004" columnIds="2003" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="130" id="2005" name="aux_UO_unit_group_slim_map" ignore="false">
+			<column id="2006" name="subset_term_id" visibleModified="false"/>
+			<column id="2007" name="distance" visibleModified="false"/>
+			<column id="2008" name="term_id" visibleModified="false"/>
+			<foreignKey id="2009" columnIds="2008" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="40" id="2010" name="aux_EFO_organ_slim_map" ignore="true">
+			<column id="2011" name="subset_term_id" visibleModified="false"/>
+			<column id="2012" name="distance" visibleModified="false"/>
+			<column id="2013" name="term_id" visibleModified="false"/>
+			<foreignKey id="2014" columnIds="2013" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="97" id="2015" name="aux_PATO_absent_slim_map" ignore="false">
+			<column id="2016" name="subset_term_id" visibleModified="false"/>
+			<column id="2017" name="distance" visibleModified="false"/>
+			<column id="2018" name="term_id" visibleModified="false"/>
+			<foreignKey id="2019" columnIds="2018" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="100" id="2020" name="aux_PATO_disposition_slim_map" ignore="false">
+			<column id="2021" name="subset_term_id" visibleModified="false"/>
+			<column id="2022" name="distance" visibleModified="false"/>
+			<column id="2023" name="term_id" visibleModified="false"/>
+			<foreignKey id="2024" columnIds="2023" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="157" id="2025" name="aux_MONDO_ordo_clinical_syndrome_map" ignore="false">
+			<column id="2026" name="subset_term_id" visibleModified="false"/>
+			<column id="2027" name="distance" visibleModified="false"/>
+			<column id="2028" name="term_id" visibleModified="false"/>
+			<foreignKey id="2029" columnIds="2028" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="128" id="2030" name="aux_TO_Zea_mays_map" ignore="false">
+			<column id="2031" name="subset_term_id" visibleModified="false"/>
+			<column id="2032" name="distance" visibleModified="false"/>
+			<column id="2033" name="term_id" visibleModified="false"/>
+			<foreignKey id="2034" columnIds="2033" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="136" id="2035" name="aux_FYPO_qc_do_not_annotate_map" ignore="false">
+			<column id="2036" name="subset_term_id" visibleModified="false"/>
+			<column id="2037" name="distance" visibleModified="false"/>
+			<column id="2038" name="term_id" visibleModified="false"/>
+			<foreignKey id="2039" columnIds="2038" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="96" id="2040" name="aux_PATO_abnormal_slim_map" ignore="false">
+			<column id="2041" name="subset_term_id" visibleModified="false"/>
+			<column id="2042" name="distance" visibleModified="false"/>
+			<column id="2043" name="term_id" visibleModified="false"/>
+			<foreignKey id="2044" columnIds="2043" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="164" id="2045" name="aux_MONDO_ordo_morphological_anomaly_map" ignore="false">
+			<column id="2046" name="subset_term_id" visibleModified="false"/>
+			<column id="2047" name="distance" visibleModified="false"/>
+			<column id="2048" name="term_id" visibleModified="false"/>
+			<foreignKey id="2049" columnIds="2048" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="127" id="2050" name="aux_TO_Triticum_aestivum_map" ignore="false">
+			<column id="2051" name="subset_term_id" visibleModified="false"/>
+			<column id="2052" name="distance" visibleModified="false"/>
+			<column id="2053" name="term_id" visibleModified="false"/>
+			<foreignKey id="2054" columnIds="2053" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="145" id="2055" name="aux_MONDO_do_inheritance_inconsistent_map" ignore="false">
+			<column id="2056" name="subset_term_id" visibleModified="false"/>
+			<column id="2057" name="distance" visibleModified="false"/>
+			<column id="2058" name="term_id" visibleModified="false"/>
+			<foreignKey id="2059" columnIds="2058" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="141" id="2060" name="aux_HP_hposlim_core_map" ignore="false">
+			<column id="2061" name="subset_term_id" visibleModified="false"/>
+			<column id="2062" name="distance" visibleModified="false"/>
+			<column id="2063" name="term_id" visibleModified="false"/>
+			<foreignKey id="2064" columnIds="2063" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="122" id="2065" name="aux_TO_Allium_porrum_map" ignore="false">
+			<column id="2066" name="subset_term_id" visibleModified="false"/>
+			<column id="2067" name="distance" visibleModified="false"/>
+			<column id="2068" name="term_id" visibleModified="false"/>
+			<foreignKey id="2069" columnIds="2068" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="144" id="2070" name="aux_MONDO_clingen_map" ignore="false">
+			<column id="2071" name="subset_term_id" visibleModified="false"/>
+			<column id="2072" name="distance" visibleModified="false"/>
+			<column id="2073" name="term_id" visibleModified="false"/>
+			<foreignKey id="2074" columnIds="2073" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="118" id="2075" name="aux_PO_Rice_map" ignore="false">
+			<column id="2076" name="subset_term_id" visibleModified="false"/>
+			<column id="2077" name="distance" visibleModified="false"/>
+			<column id="2078" name="term_id" visibleModified="false"/>
+			<foreignKey id="2079" columnIds="2078" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="65" id="2080" name="aux_MP_Sanger_Terms_map" ignore="true">
+			<column id="2081" name="subset_term_id" visibleModified="false"/>
+			<column id="2082" name="distance" visibleModified="false"/>
+			<column id="2083" name="term_id" visibleModified="false"/>
+			<foreignKey id="2084" columnIds="2083" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="152" id="2085" name="aux_MONDO_n_of_one_map" ignore="false">
+			<column id="2086" name="subset_term_id" visibleModified="false"/>
+			<column id="2087" name="distance" visibleModified="false"/>
+			<column id="2088" name="term_id" visibleModified="false"/>
+			<foreignKey id="2089" columnIds="2088" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="163" id="2090" name="aux_MONDO_ordo_malformation_syndrome_map" ignore="false">
+			<column id="2091" name="subset_term_id" visibleModified="false"/>
+			<column id="2092" name="distance" visibleModified="false"/>
+			<column id="2093" name="term_id" visibleModified="false"/>
+			<foreignKey id="2094" columnIds="2093" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="140" id="2095" name="aux_GO_goslim_flybase_ribbon_map" ignore="false">
+			<column id="2096" name="subset_term_id" visibleModified="false"/>
+			<column id="2097" name="distance" visibleModified="false"/>
+			<column id="2098" name="term_id" visibleModified="false"/>
+			<foreignKey id="2099" columnIds="2098" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="134" id="2100" name="aux_CHEBI_3_STAR_map" ignore="false">
+			<column id="2101" name="subset_term_id" visibleModified="false"/>
+			<column id="2102" name="distance" visibleModified="false"/>
+			<column id="2103" name="term_id" visibleModified="false"/>
+			<foreignKey id="2104" columnIds="2103" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="11" id="2105" name="aux_GO_goslim_plant_map" ignore="true">
+			<column id="2106" name="subset_term_id" visibleModified="false"/>
+			<column id="2107" name="distance" visibleModified="false"/>
+			<column id="2108" name="term_id" visibleModified="false"/>
+			<foreignKey id="2109" columnIds="2108" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="20" id="2110" name="synonym" ignore="false">
+			<column id="2111" name="synonym_id" visibleModified="false"/>
+			<column id="2112" name="dbxref" visibleModified="false"/>
+			<column id="2113" name="name" visibleModified="false"/>
+			<column id="2114" name="term_id" visibleModified="false"/>
+			<column id="2115" name="type" visibleModified="false"/>
+			<primaryKey id="2116" columnIds="2111" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2117" columnIds="2114" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="160" id="2118" name="aux_MONDO_ordo_group_of_disorders_map" ignore="false">
+			<column id="2119" name="subset_term_id" visibleModified="false"/>
+			<column id="2120" name="distance" visibleModified="false"/>
+			<column id="2121" name="term_id" visibleModified="false"/>
+			<foreignKey id="2122" columnIds="2121" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="150" id="2123" name="aux_MONDO_metaclass_map" ignore="false">
+			<column id="2124" name="subset_term_id" visibleModified="false"/>
+			<column id="2125" name="distance" visibleModified="false"/>
+			<column id="2126" name="term_id" visibleModified="false"/>
+			<foreignKey id="2127" columnIds="2126" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="12" id="2128" name="aux_GO_goslim_pombe_map" ignore="true">
+			<column id="2129" name="subset_term_id" visibleModified="false"/>
+			<column id="2130" name="distance" visibleModified="false"/>
+			<column id="2131" name="term_id" visibleModified="false"/>
+			<foreignKey id="2132" columnIds="2131" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="112" id="2133" name="aux_PO_Gymnosperms_map" ignore="false">
+			<column id="2134" name="subset_term_id" visibleModified="false"/>
+			<column id="2135" name="distance" visibleModified="false"/>
+			<column id="2136" name="term_id" visibleModified="false"/>
+			<foreignKey id="2137" columnIds="2136" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="41" id="2138" name="aux_EFO_uberon_slim_map" ignore="true">
+			<column id="2139" name="subset_term_id" visibleModified="false"/>
+			<column id="2140" name="distance" visibleModified="false"/>
+			<column id="2141" name="term_id" visibleModified="false"/>
+			<foreignKey id="2142" columnIds="2141" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="29" id="2143" name="aux_GO_gocheck_do_not_annotate_map" ignore="true">
+			<column id="2144" name="subset_term_id" visibleModified="false"/>
+			<column id="2145" name="distance" visibleModified="false"/>
+			<column id="2146" name="term_id" visibleModified="false"/>
+			<foreignKey id="2147" columnIds="2146" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="67" id="2148" name="aux_ECO_go_groupings_map" ignore="false">
+			<column id="2149" name="subset_term_id" visibleModified="false"/>
+			<column id="2150" name="distance" visibleModified="false"/>
+			<column id="2151" name="term_id" visibleModified="false"/>
+			<foreignKey id="2152" columnIds="2151" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="123" id="2153" name="aux_TO_Cucurbita_map" ignore="false">
+			<column id="2154" name="subset_term_id" visibleModified="false"/>
+			<column id="2155" name="distance" visibleModified="false"/>
+			<column id="2156" name="term_id" visibleModified="false"/>
+			<foreignKey id="2157" columnIds="2156" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="27" id="2158" name="alt_id" ignore="false">
+			<column id="2159" name="accession" visibleModified="false"/>
+			<column id="2160" name="term_id" visibleModified="false"/>
+			<column id="2161" name="alt_id" visibleModified="false"/>
+			<primaryKey id="2162" columnIds="2161" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2163" columnIds="2160" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="107" id="2164" name="aux_PO_Angiosperm_map" ignore="false">
+			<column id="2165" name="subset_term_id" visibleModified="false"/>
+			<column id="2166" name="distance" visibleModified="false"/>
+			<column id="2167" name="term_id" visibleModified="false"/>
+			<foreignKey id="2168" columnIds="2167" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="132" id="2169" name="aux_CHEBI_1_STAR_map" ignore="false">
+			<column id="2170" name="subset_term_id" visibleModified="false"/>
+			<column id="2171" name="distance" visibleModified="false"/>
+			<column id="2172" name="term_id" visibleModified="false"/>
+			<foreignKey id="2173" columnIds="2172" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="146" id="2174" name="aux_MONDO_gard_rare_map" ignore="false">
+			<column id="2175" name="subset_term_id" visibleModified="false"/>
+			<column id="2176" name="distance" visibleModified="false"/>
+			<column id="2177" name="term_id" visibleModified="false"/>
+			<foreignKey id="2178" columnIds="2177" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="10" id="2179" name="aux_GO_goslim_pir_map" ignore="true">
+			<column id="2180" name="subset_term_id" visibleModified="false"/>
+			<column id="2181" name="distance" visibleModified="false"/>
+			<column id="2182" name="term_id" visibleModified="false"/>
+			<foreignKey id="2183" columnIds="2182" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="21" id="2184" name="aux_SO_DBVAR_map" ignore="true">
+			<column id="2185" name="subset_term_id" visibleModified="false"/>
+			<column id="2186" name="distance" visibleModified="false"/>
+			<column id="2187" name="term_id" visibleModified="false"/>
+			<foreignKey id="2188" columnIds="2187" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="121" id="2189" name="aux_PO_reference_map" ignore="false">
+			<column id="2190" name="subset_term_id" visibleModified="false"/>
+			<column id="2191" name="distance" visibleModified="false"/>
+			<column id="2192" name="term_id" visibleModified="false"/>
+			<foreignKey id="2193" columnIds="2192" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="73" id="2194" name="aux_ECO_valid_with_protein_complex_map" ignore="false">
+			<column id="2195" name="subset_term_id" visibleModified="false"/>
+			<column id="2196" name="distance" visibleModified="false"/>
+			<column id="2197" name="term_id" visibleModified="false"/>
+			<foreignKey id="2198" columnIds="2197" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="148" id="2199" name="aux_MONDO_implicit_genetic_in_ordo_map" ignore="false">
+			<column id="2200" name="subset_term_id" visibleModified="false"/>
+			<column id="2201" name="distance" visibleModified="false"/>
+			<column id="2202" name="term_id" visibleModified="false"/>
+			<foreignKey id="2203" columnIds="2202" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="114" id="2204" name="aux_PO_Musa_map" ignore="false">
+			<column id="2205" name="subset_term_id" visibleModified="false"/>
+			<column id="2206" name="distance" visibleModified="false"/>
+			<column id="2207" name="term_id" visibleModified="false"/>
+			<foreignKey id="2208" columnIds="2207" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="102" id="2209" name="aux_PATO_mpath_slim_map" ignore="false">
+			<column id="2210" name="subset_term_id" visibleModified="false"/>
+			<column id="2211" name="distance" visibleModified="false"/>
+			<column id="2212" name="term_id" visibleModified="false"/>
+			<foreignKey id="2213" columnIds="2212" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="15" id="2214" name="aux_SO_SOFA_map" ignore="true">
+			<column id="2215" name="subset_term_id" visibleModified="false"/>
+			<column id="2216" name="distance" visibleModified="false"/>
+			<column id="2217" name="term_id" visibleModified="false"/>
+			<foreignKey id="2218" columnIds="2217" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="72" id="2219" name="aux_ECO_valid_with_molecular_function_map" ignore="false">
+			<column id="2220" name="subset_term_id" visibleModified="false"/>
+			<column id="2221" name="distance" visibleModified="false"/>
+			<column id="2222" name="term_id" visibleModified="false"/>
+			<foreignKey id="2223" columnIds="2222" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="167" id="2224" name="aux_MONDO_prototype_pattern_map" ignore="false">
+			<column id="2225" name="subset_term_id" visibleModified="false"/>
+			<column id="2226" name="distance" visibleModified="false"/>
+			<column id="2227" name="term_id" visibleModified="false"/>
+			<foreignKey id="2228" columnIds="2227" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="147" id="2229" name="aux_MONDO_historic_epidemic_map" ignore="false">
+			<column id="2230" name="subset_term_id" visibleModified="false"/>
+			<column id="2231" name="distance" visibleModified="false"/>
+			<column id="2232" name="term_id" visibleModified="false"/>
+			<foreignKey id="2233" columnIds="2232" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="153" id="2234" name="aux_MONDO_obsoletion_candidate_map" ignore="false">
+			<column id="2235" name="subset_term_id" visibleModified="false"/>
+			<column id="2236" name="distance" visibleModified="false"/>
+			<column id="2237" name="term_id" visibleModified="false"/>
+			<foreignKey id="2238" columnIds="2237" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="63" id="2239" name="aux_MP_IMPC_Prenatal_map" ignore="true">
+			<column id="2240" name="subset_term_id" visibleModified="false"/>
+			<column id="2241" name="distance" visibleModified="false"/>
+			<column id="2242" name="term_id" visibleModified="false"/>
+			<foreignKey id="2243" columnIds="2242" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="17" id="2244" name="subset" ignore="false">
+			<column id="2245" name="subset_id" visibleModified="false"/>
+			<column id="2246" name="name" visibleModified="false"/>
+			<column id="2247" name="definition" visibleModified="false"/>
+			<primaryKey id="2248" columnIds="2245" status="INFERRED" visibleModified="false"/>
+		</table>
+		<relation id="2249" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1967" status="INFERRED" visibleModified="false"/>
+		<relation id="2250" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2147" status="INFERRED" visibleModified="false"/>
+		<relation id="2251" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2024" status="INFERRED" visibleModified="false"/>
+		<relation id="2252" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2104" status="INFERRED" visibleModified="false"/>
+		<relation id="2253" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1709" status="INFERRED" visibleModified="false"/>
+		<relation id="2254" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1883" status="INFERRED" visibleModified="false"/>
+		<relation id="2255" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2074" status="INFERRED" visibleModified="false"/>
+		<relation id="2256" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1800" status="INFERRED" visibleModified="false"/>
+		<relation id="2257" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2132" status="INFERRED" visibleModified="false"/>
+		<relation id="2258" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1927" status="INFERRED" visibleModified="false"/>
+		<relation id="2259" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1649" status="INFERRED" visibleModified="false"/>
+		<relation id="2260" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2049" status="INFERRED" visibleModified="false"/>
+		<relation id="2261" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1898" status="INFERRED" visibleModified="false"/>
+		<relation id="2262" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1669" status="INFERRED" visibleModified="false"/>
+		<relation id="2263" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1922" status="INFERRED" visibleModified="false"/>
+		<relation id="2264" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1699" status="INFERRED" visibleModified="false"/>
+		<relation id="2265" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1932" status="INFERRED" visibleModified="false"/>
+		<relation id="2266" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1947" status="INFERRED" visibleModified="false"/>
+		<relation id="2267" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1823" status="INFERRED" visibleModified="false"/>
+		<relation id="2268" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1989" secondKeyId="1982" status="INFERRED" visibleModified="false"/>
+		<relation id="2269" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1750" status="INFERRED" visibleModified="false"/>
+		<relation id="2270" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1903" status="INFERRED" visibleModified="false"/>
+		<relation id="2271" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1729" status="INFERRED" visibleModified="false"/>
+		<relation id="2272" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1999" status="INFERRED" visibleModified="false"/>
+		<relation id="2273" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2044" status="INFERRED" visibleModified="false"/>
+		<relation id="2274" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1795" status="INFERRED" visibleModified="false"/>
+		<relation id="2275" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2188" status="INFERRED" visibleModified="false"/>
+		<relation id="2276" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1957" status="INFERRED" visibleModified="false"/>
+		<relation id="2277" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1724" status="INFERRED" visibleModified="false"/>
+		<relation id="2278" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1745" status="INFERRED" visibleModified="false"/>
+		<relation id="2279" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1775" status="INFERRED" visibleModified="false"/>
+		<relation id="2280" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2223" status="INFERRED" visibleModified="false"/>
+		<relation id="2281" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1828" status="INFERRED" visibleModified="false"/>
+		<relation id="2282" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2034" status="INFERRED" visibleModified="false"/>
+		<relation id="2283" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1893" status="INFERRED" visibleModified="false"/>
+		<relation id="2284" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1760" status="INFERRED" visibleModified="false"/>
+		<relation id="2285" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1952" status="INFERRED" visibleModified="false"/>
+		<relation id="2286" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1833" status="INFERRED" visibleModified="false"/>
+		<relation id="2287" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2084" status="INFERRED" visibleModified="false"/>
+		<relation id="2288" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1838" status="INFERRED" visibleModified="false"/>
+		<relation id="2289" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1734" status="INFERRED" visibleModified="false"/>
+		<relation id="2290" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2069" status="INFERRED" visibleModified="false"/>
+		<relation id="2291" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2203" status="INFERRED" visibleModified="false"/>
+		<relation id="2292" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1659" status="INFERRED" visibleModified="false"/>
+		<relation id="2293" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1704" status="INFERRED" visibleModified="false"/>
+		<relation id="2294" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2122" status="INFERRED" visibleModified="false"/>
+		<relation id="2295" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2218" status="INFERRED" visibleModified="false"/>
+		<relation id="2296" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2213" status="INFERRED" visibleModified="false"/>
+		<relation id="2297" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2243" status="INFERRED" visibleModified="false"/>
+		<relation id="2298" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2109" status="INFERRED" visibleModified="false"/>
+		<relation id="2299" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1972" status="INFERRED" visibleModified="false"/>
+		<relation id="2300" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1868" status="INFERRED" visibleModified="false"/>
+		<relation id="2301" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2064" status="INFERRED" visibleModified="false"/>
+		<relation id="2302" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1848" status="INFERRED" visibleModified="false"/>
+		<relation id="2303" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2137" status="INFERRED" visibleModified="false"/>
+		<relation id="2304" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1913" status="INFERRED" visibleModified="false"/>
+		<relation id="2305" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2004" status="INFERRED" visibleModified="false"/>
+		<relation id="2306" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1755" status="INFERRED" visibleModified="false"/>
+		<relation id="2307" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1843" status="INFERRED" visibleModified="false"/>
+		<relation id="2308" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1878" status="INFERRED" visibleModified="false"/>
+		<relation id="2309" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2094" status="INFERRED" visibleModified="false"/>
+		<relation id="2310" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2168" status="INFERRED" visibleModified="false"/>
+		<relation id="2311" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1770" status="INFERRED" visibleModified="false"/>
+		<relation id="2312" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2163" status="INFERRED" visibleModified="false"/>
+		<relation id="2313" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2054" status="INFERRED" visibleModified="false"/>
+		<relation id="2314" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1873" status="INFERRED" visibleModified="false"/>
+		<relation id="2315" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2039" status="INFERRED" visibleModified="false"/>
+		<relation id="2316" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1858" status="INFERRED" visibleModified="false"/>
+		<relation id="2317" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2079" status="INFERRED" visibleModified="false"/>
+		<relation id="2318" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1654" status="INFERRED" visibleModified="false"/>
+		<relation id="2319" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1989" secondKeyId="1679" status="INFERRED" visibleModified="false"/>
+		<relation id="2320" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2208" status="INFERRED" visibleModified="false"/>
+		<relation id="2321" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1962" status="INFERRED" visibleModified="false"/>
+		<relation id="2322" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1785" status="INFERRED" visibleModified="false"/>
+		<relation id="2323" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1863" status="INFERRED" visibleModified="false"/>
+		<relation id="2324" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1780" status="INFERRED" visibleModified="false"/>
+		<relation id="2325" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2142" status="INFERRED" visibleModified="false"/>
+		<relation id="2326" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2127" status="INFERRED" visibleModified="false"/>
+		<relation id="2327" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1719" status="INFERRED" visibleModified="false"/>
+		<relation id="2328" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1714" status="INFERRED" visibleModified="false"/>
+		<relation id="2329" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1917" secondKeyId="1678" status="INFERRED" visibleModified="false"/>
+		<relation id="2330" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1689" status="INFERRED" visibleModified="false"/>
+		<relation id="2331" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1694" status="INFERRED" visibleModified="false"/>
+		<relation id="2332" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2193" status="INFERRED" visibleModified="false"/>
+		<relation id="2333" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2117" status="INFERRED" visibleModified="false"/>
+		<relation id="2334" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1942" status="INFERRED" visibleModified="false"/>
+		<relation id="2335" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1790" status="INFERRED" visibleModified="false"/>
+		<relation id="2336" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2014" status="INFERRED" visibleModified="false"/>
+		<relation id="2337" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2228" status="INFERRED" visibleModified="false"/>
+		<relation id="2338" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1684" status="INFERRED" visibleModified="false"/>
+		<relation id="2339" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2157" status="INFERRED" visibleModified="false"/>
+		<relation id="2340" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2029" status="INFERRED" visibleModified="false"/>
+		<relation id="2341" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2183" status="INFERRED" visibleModified="false"/>
+		<relation id="2342" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2178" status="INFERRED" visibleModified="false"/>
+		<relation id="2343" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1888" status="INFERRED" visibleModified="false"/>
+		<relation id="2344" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2059" status="INFERRED" visibleModified="false"/>
+		<relation id="2345" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2238" status="INFERRED" visibleModified="false"/>
+		<relation id="2346" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1853" status="INFERRED" visibleModified="false"/>
+		<relation id="2347" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2198" status="INFERRED" visibleModified="false"/>
+		<relation id="2348" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1989" secondKeyId="1817" status="INFERRED" visibleModified="false"/>
+		<relation id="2349" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2089" status="INFERRED" visibleModified="false"/>
+		<relation id="2350" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2009" status="INFERRED" visibleModified="false"/>
+		<relation id="2351" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2099" status="INFERRED" visibleModified="false"/>
+		<relation id="2352" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1908" status="INFERRED" visibleModified="false"/>
+		<relation id="2353" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2233" status="INFERRED" visibleModified="false"/>
+		<relation id="2354" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1765" status="INFERRED" visibleModified="false"/>
+		<relation id="2355" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2173" status="INFERRED" visibleModified="false"/>
+		<relation id="2356" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1994" status="INFERRED" visibleModified="false"/>
+		<relation id="2357" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2152" status="INFERRED" visibleModified="false"/>
+		<relation id="2358" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1805" status="INFERRED" visibleModified="false"/>
+		<relation id="2359" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1937" status="INFERRED" visibleModified="false"/>
+		<relation id="2360" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="1664" status="INFERRED" visibleModified="false"/>
+		<relation id="2361" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1816" secondKeyId="2019" status="INFERRED" visibleModified="false"/>
+	</jdbcSchema>
+	<jdbcSchema uniqueId="2" driverClassName="com.mysql.jdbc.Driver" url="jdbc:mysql://%HOST%:%PORT%/master_schema_variation_%ENS%" databaseName="master_schema_variation_%ENS%" schemaName="master_schema_variation_%ENS%" username="%USER%" password="%PASS%" name="variation" keyguessing="true" masked="false" hideMasked="false" partitionRegex="^(.)[^_]+_?[a-z0-9]+?_([a-z0-9]+)_variation_%PARTITION_REGEX%_[0-9]*$" partitionExpression="%PARTITION_EXPRESSION%">
+		<table uniqueId="108" id="2362" name="regulatory_feature_variation" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2363" name="feature_type" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2364" name="consequence_types" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2365" name="regulatory_feature_variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2366" name="feature_stable_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2367" name="allele_string" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2368" name="somatic" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2369" name="variation_feature_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2370" columnIds="2365" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2371" columnIds="2369" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="150" id="2372" name="MTMP_motif_feature_variation" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2373" name="consequence_types" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2374" name="feature_stable_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2375" name="allele_string" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2376" name="motif_score_delta" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2377" name="in_informative_position" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2378" name="motif_start" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2379" name="variation_feature_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2380" name="motif_name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<foreignKey id="2381" columnIds="2379" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="72" id="2382" name="variation_set" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2383" name="short_name_attrib_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2384" name="variation_set_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2385" name="name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2386" name="description" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2387" columnIds="2384" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="71" id="2388" name="structural_variation" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2389" name="copy_number" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2390" name="clinical_significance" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2391" name="structural_variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2392" name="variation_name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2393" name="alias" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2394" name="somatic" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2395" name="validation_status" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2396" name="study_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2397" name="source_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2398" name="class_attrib_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2399" name="is_evidence" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2400" columnIds="2391" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2401" columnIds="2397" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2402" columnIds="2396" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="34" id="2403" name="subsnp_handle" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2404" name="handle" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2405" name="subsnp_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2406" columnIds="2405" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="120" id="2407" name="population_synonym" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2408" name="synonym_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2409" name="population_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2410" name="name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2411" name="source_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2412" columnIds="2408" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2413" columnIds="2409" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2414" columnIds="2411" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="73" id="2415" name="variation_set_structure" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2416" name="variation_set_sub" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2417" name="variation_set_super" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2418" columnIds="2417,2416" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="21" id="2419" name="source" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2420" name="somatic_status" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2421" name="name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2422" name="description" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2423" name="source_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2424" name="type" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2425" name="version" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2426" name="data_types" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2427" name="url" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2428" columnIds="2423" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="25" id="2429" name="variation" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2430" name="flipped" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2431" name="ancestral_allele" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2432" name="display" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2433" name="minor_allele" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2434" name="class_attrib_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2435" name="evidence_attribs" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2436" name="minor_allele_count" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2437" name="minor_allele_freq" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2438" name="clinical_significance" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2439" name="variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2440" name="name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2441" name="somatic" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2442" name="source_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2443" columnIds="2439" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2444" columnIds="2442" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="133" id="2445" name="MTMP_phenotype" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2446" name="p_value" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2447" name="strain_gender" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2448" name="strain_name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2449" name="gene_stable_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2450" name="description" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2451" name="external_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2452" name="source" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2453" name="mtmp_phenotype_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2454" columnIds="2453" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2455" columnIds="2449" status="HANDMADE" visibleModified="false"/>
+		</table>
+		<table uniqueId="98" id="2456" name="failed_structural_variation" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2457" name="structural_variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2458" name="failed_structural_variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2459" name="failed_description_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2460" columnIds="2458" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2461" columnIds="2457" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2462" columnIds="2459" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="104" id="2463" name="coord_system" ignore="true" inSchemaPartition="variation_species_list">
+			<column id="2464" name="species_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2465" name="coord_system_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2466" name="attrib" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2467" name="name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2468" name="rank" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2469" name="version" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2470" columnIds="2465" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="121" id="2471" name="publication" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2472" name="publication_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2473" name="year" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2474" name="ucsc_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2475" name="pmcid" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2476" name="title" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2477" name="pmid" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2478" name="authors" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2479" name="doi" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2480" columnIds="2472" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="102" id="2481" name="variation_set_structural_variation" ignore="true" inSchemaPartition="variation_species_list">
+			<column id="2482" name="variation_set_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2483" name="structural_variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2484" columnIds="2483,2482" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2485" columnIds="2482" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2486" columnIds="2483" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="126" id="2487" name="variation_genename" ignore="true" inSchemaPartition="variation_species_list">
+			<column id="2488" name="gene_name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2489" name="variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2490" columnIds="2489,2488" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2491" columnIds="2489" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="130" id="2492" name="variation_attrib" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2493" name="variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2494" name="attrib_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2495" name="value" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<foreignKey id="2496" columnIds="2493" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2497" columnIds="2494" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="105" id="2498" name="translation_md5" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2499" name="translation_md5_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2500" name="translation_md5" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2501" columnIds="2499" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="9" id="2502" name="individual" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2503" name="individual_type_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2504" name="gender" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2505" name="mother_individual_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2506" name="name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2507" name="description" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2508" name="father_individual_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2509" name="individual_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2510" columnIds="2509" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2511" columnIds="2503" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="144" id="2512" name="sample_population" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2513" name="population_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2514" name="sample_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<foreignKey id="2515" columnIds="2514" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2516" columnIds="2513" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="145" id="2517" name="tmp_sample_genotype_single_bp" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2518" name="allele_2" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2519" name="variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2520" name="sample_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2521" name="subsnp_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2522" name="allele_1" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<foreignKey id="2523" columnIds="2519" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2524" columnIds="2520" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="96" id="2525" name="compressed_genotype_region" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2526" name="seq_region_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2527" name="sample_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2528" name="genotypes" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2529" name="seq_region_strand" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2530" name="seq_region_end" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2531" name="seq_region_start" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<foreignKey id="2532" columnIds="2526" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2533" columnIds="2527" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="154" id="2534" name="allele_synonym" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2535" name="hgvs_genomic" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2536" name="variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2537" name="name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2538" name="allele_synonym_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2539" columnIds="2538" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2540" columnIds="2536" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="128" id="2541" name="display_group" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2542" name="display_group_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2543" name="display_priority" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2544" name="display_name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2545" columnIds="2542" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="91" id="2546" name="structural_variation_feature" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2547" name="outer_end" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2548" name="structural_variation_feature_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2549" name="variation_name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2550" name="structural_variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2551" name="length" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2552" name="seq_region_end" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2553" name="study_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2554" name="class_attrib_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2555" name="breakpoint_order" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2556" name="is_evidence" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2557" name="seq_region_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2558" name="allele_string" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2559" name="variation_set_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2560" name="seq_region_strand" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2561" name="somatic" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2562" name="source_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2563" name="inner_start" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2564" name="outer_start" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2565" name="inner_end" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2566" name="seq_region_start" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2567" columnIds="2548" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2568" columnIds="2550" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2569" columnIds="2562" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2570" columnIds="2557" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2571" columnIds="2559" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2572" columnIds="2553" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="90" id="2573" name="protein_function_predictions" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2574" name="prediction_matrix" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2575" name="analysis_attrib_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2576" name="translation_md5_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2577" columnIds="2576,2575" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2578" columnIds="2576" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="15" id="2579" name="population" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2580" name="size" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2581" name="population_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2582" name="display" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2583" name="name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2584" name="description" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2585" name="display_group_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2586" name="collection" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2587" name="freqs_from_gts" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2588" columnIds="2581" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2589" columnIds="2585" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="139" id="2590" name="MTMP_variation_set_variation" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2591" name="variation_set_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2592" name="variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<foreignKey id="2593" columnIds="2591" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2594" columnIds="2592" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="101" id="2595" name="structural_variation_association" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2596" name="supporting_structural_variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2597" name="structural_variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2598" columnIds="2597,2596" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2599" columnIds="2597" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="95" id="2600" name="allele_code" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2601" name="allele_code_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2602" name="allele" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2603" columnIds="2601" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="17" id="2604" name="population_structure" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2605" name="sub_population_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2606" name="super_population_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+		</table>
+		<table uniqueId="13" id="2607" name="meta" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2608" name="species_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2609" name="meta_value" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2610" name="meta_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2611" name="meta_key" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2612" columnIds="2610" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="16" id="2613" name="population_genotype" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2614" name="population_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2615" name="variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2616" name="count" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2617" name="subsnp_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2618" name="population_genotype_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2619" name="genotype_code_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2620" name="frequency" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2621" columnIds="2618" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2622" columnIds="2615" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2623" columnIds="2619" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2624" columnIds="2614" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="107" id="2625" name="motif_feature_variation" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2626" name="consequence_types" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2627" name="motif_feature_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2628" name="feature_stable_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2629" name="motif_end" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2630" name="motif_score_delta" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2631" name="allele_string" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2632" name="motif_feature_variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2633" name="in_informative_position" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2634" name="motif_start" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2635" name="somatic" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2636" name="variation_feature_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2637" name="binding_matrix_stable_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2638" columnIds="2632" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2639" columnIds="2636" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="155" id="2640" name="failed_variation_feature" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2641" name="failed_description_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2642" name="failed_variation_feature_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2643" name="variation_feature_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2644" columnIds="2642" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2645" columnIds="2641" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2646" columnIds="2643" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="156" id="2647" name="submitter" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2648" name="submitter_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2649" name="description" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2650" columnIds="2648" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="87" id="2651" name="study" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2652" name="study_type" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2653" name="external_reference" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2654" name="name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2655" name="description" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2656" name="study_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2657" name="source_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2658" name="url" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2659" columnIds="2656" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2660" columnIds="2657" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="82" id="2661" name="failed_allele" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2662" name="allele_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2663" name="failed_description_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2664" name="failed_allele_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2665" columnIds="2664" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2666" columnIds="2663" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2667" columnIds="2662" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="78" id="2668" name="associate_study" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2669" name="study2_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2670" name="study1_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2671" columnIds="2670,2669" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="132" id="2672" name="MTMP_regulatory_feature_variation" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2673" name="consequence_types" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2674" name="feature_stable_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2675" name="allele_string" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2676" name="variation_feature_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<foreignKey id="2677" columnIds="2676" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="140" id="2678" name="protein_function_predictions_attrib" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2679" name="analysis_attrib_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2680" name="translation_md5_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2681" name="attrib_type_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2682" name="position_values" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2683" columnIds="2680,2679,2681" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2684" columnIds="2681" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2685" columnIds="2680" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="129" id="2686" name="read_coverage" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2687" name="seq_region_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2688" name="level" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2689" name="sample_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2690" name="seq_region_end" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2691" name="seq_region_start" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<foreignKey id="2692" columnIds="2687" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2693" columnIds="2689" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="134" id="2694" name="MTMP_evidence" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2695" name="evidence" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2696" name="variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2697" columnIds="2696" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2698" columnIds="2696" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="124" id="2699" name="variation_hgvs" ignore="true" inSchemaPartition="variation_species_list">
+			<column id="2700" name="variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2701" name="hgvs_name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2702" columnIds="2700,2701" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2703" columnIds="2700" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="5" id="2704" name="failed_description" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2705" name="failed_description_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2706" name="description" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2707" columnIds="2705" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="76" id="2708" name="MTMP_transcript_variation" ignore="true" inSchemaPartition="variation_species_list">
+			<column id="2709" name="cds_end" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2710" name="consequence_types" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2711" name="feature_stable_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2712" name="distance_to_transcript" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2713" name="translation_end" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2714" name="display" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2715" name="variation_feature_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2716" name="cdna_end" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2717" name="sift_score" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2718" name="cdna_start" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2719" name="allele_string" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2720" name="polyphen_score" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2721" name="cds_start" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2722" name="translation_start" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2723" name="polyphen_prediction" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2724" name="sift_prediction" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2725" name="pep_allele_string" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<foreignKey id="2726" columnIds="2715" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2727" columnIds="2711" status="HANDMADE" visibleModified="false"/>
+		</table>
+		<table uniqueId="99" id="2728" name="genotype_code" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2729" name="allele_code_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2730" name="haplotype_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2731" name="genotype_code_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2732" name="phased" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2733" columnIds="2731" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2734" columnIds="2729" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="149" id="2735" name="sample_synonym" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2736" name="synonym_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2737" name="sample_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2738" name="name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2739" name="source_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2740" columnIds="2736" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2741" columnIds="2737" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2742" columnIds="2739" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="32" id="2743" name="seq_region" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2744" name="seq_region_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2745" name="coord_system_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2746" name="name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2747" columnIds="2744" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2748" columnIds="2745" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="80" id="2749" name="attrib_set" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2750" name="attrib_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2751" name="attrib_set_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2752" columnIds="2751" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2753" columnIds="2750" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="119" id="2754" name="individual_synonym" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2755" name="synonym_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2756" name="name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2757" name="source_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2758" name="individual_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2759" columnIds="2755" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2760" columnIds="2758" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2761" columnIds="2757" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="79" id="2762" name="attrib" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2763" name="attrib_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2764" name="attrib_type_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2765" name="value" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2766" columnIds="2763" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2767" columnIds="2764" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="157" id="2768" name="MTMP_population_genotype" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2769" name="allele_2" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2770" name="population_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2771" name="variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2772" name="count" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2773" name="subsnp_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2774" name="population_genotype_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2775" name="allele_1" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2776" name="frequency" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2777" columnIds="2774" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2778" columnIds="2771" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2779" columnIds="2770" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2780" columnIds="2774" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="24" id="2781" name="transcript_variation" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2782" name="cds_end" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2783" name="consequence_types" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2784" name="feature_stable_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2785" name="distance_to_transcript" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2786" name="translation_end" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2787" name="display" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2788" name="hgvs_protein" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2789" name="variation_feature_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2790" name="cdna_end" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2791" name="hgvs_transcript" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2792" name="sift_score" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2793" name="codon_allele_string" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2794" name="hgvs_genomic" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2795" name="cdna_start" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2796" name="transcript_variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2797" name="allele_string" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2798" name="polyphen_score" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2799" name="cds_start" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2800" name="translation_start" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2801" name="polyphen_prediction" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2802" name="somatic" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2803" name="sift_prediction" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2804" name="pep_allele_string" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2805" columnIds="2796" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2806" columnIds="2789" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="6" id="2807" name="failed_variation" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2808" name="variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2809" name="failed_description_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2810" name="failed_variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2811" columnIds="2810" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2812" columnIds="2809" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2813" columnIds="2808" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="81" id="2814" name="attrib_type" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2815" name="code" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2816" name="name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2817" name="description" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2818" name="attrib_type_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2819" columnIds="2818" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="12" id="2820" name="individual_type" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2821" name="individual_type_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2822" name="name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2823" name="description" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2824" columnIds="2821" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="123" id="2825" name="variation_citation" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2826" name="publication_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2827" name="variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2828" columnIds="2827,2826" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2829" columnIds="2827" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2830" columnIds="2826" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="31" id="2831" name="phenotype" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2832" name="stable_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2833" name="name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2834" name="description" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2835" name="phenotype_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2836" columnIds="2835" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="106" id="2837" name="submitter_handle" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2838" name="handle_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2839" name="handle" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2840" columnIds="2838" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="30" id="2841" name="variation_synonym" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2842" name="variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2843" name="name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2844" name="variation_synonym_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2845" name="source_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2846" name="subsnp_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2847" columnIds="2844" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2848" columnIds="2842" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2849" columnIds="2845" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="74" id="2850" name="variation_set_variation" ignore="true" inSchemaPartition="variation_species_list">
+			<column id="2851" name="variation_set_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2852" name="variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2853" columnIds="2852,2851" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2854" columnIds="2851" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2855" columnIds="2852" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="26" id="2856" name="variation_feature" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2857" name="consequence_types" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2858" name="map_weight" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2859" name="variation_name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2860" name="display" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2861" name="flags" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2862" name="seq_region_end" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2863" name="variation_feature_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2864" name="minor_allele" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2865" name="class_attrib_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2866" name="evidence_attribs" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2867" name="minor_allele_count" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2868" name="minor_allele_freq" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2869" name="seq_region_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2870" name="allele_string" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2871" name="clinical_significance" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2872" name="variation_set_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2873" name="variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2874" name="seq_region_strand" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2875" name="somatic" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2876" name="source_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2877" name="alignment_quality" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2878" name="seq_region_start" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2879" columnIds="2863" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2880" columnIds="2873" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2881" columnIds="2876" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2882" columnIds="2869" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2883" columnIds="2872" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="142" id="2884" name="sample" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2885" name="has_coverage" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2886" name="variation_set_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2887" name="display" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2888" name="sample_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2889" name="name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2890" name="description" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2891" name="study_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2892" name="individual_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2893" columnIds="2888" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2894" columnIds="2886" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2895" columnIds="2892" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2896" columnIds="2891" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="97" id="2897" name="compressed_genotype_var" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2898" name="variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2899" name="genotypes" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2900" name="subsnp_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<foreignKey id="2901" columnIds="2898" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="122" id="2902" name="structural_variation_sample" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2903" name="zygosity" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2904" name="structural_variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2905" name="sample_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2906" name="structural_variation_sample_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2907" columnIds="2906" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2908" columnIds="2904" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2909" columnIds="2905" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="148" id="2910" name="phenotype_ontology_accession" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2911" name="mapped_by_attrib" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2912" name="mapping_type" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2913" name="phenotype_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2914" name="accession" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2915" columnIds="2913,2914" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2916" columnIds="2913" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="111" id="2917" name="phenotype_feature" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2918" name="seq_region_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2919" name="is_significant" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2920" name="phenotype_feature_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2921" name="seq_region_strand" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2922" name="phenotype_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2923" name="source_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2924" name="study_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2925" name="seq_region_end" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2926" name="type" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2927" name="object_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2928" name="seq_region_start" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2929" columnIds="2920" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2930" columnIds="2918" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2931" columnIds="2924" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2932" columnIds="2922" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2933" columnIds="2923" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="112" id="2934" name="phenotype_feature_attrib" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2935" name="phenotype_feature_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2936" name="attrib_type_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2937" name="value" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<foreignKey id="2938" columnIds="2936" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2939" columnIds="2935" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="14" id="2940" name="meta_coord" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2941" name="coord_system_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2942" name="table_name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2943" name="max_length" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<foreignKey id="2944" columnIds="2941" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="1" id="2945" name="allele" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2946" name="allele_code_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2947" name="allele_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2948" name="population_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2949" name="variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2950" name="count" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2951" name="frequency_submitter_handle" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2952" name="subsnp_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2953" name="frequency" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2954" columnIds="2947" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2955" columnIds="2949" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2956" columnIds="2946" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2957" columnIds="2948" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="143" id="2958" name="sample_genotype_multiple_bp" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2959" name="allele_2" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2960" name="variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2961" name="sample_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2962" name="subsnp_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2963" name="allele_1" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<foreignKey id="2964" columnIds="2960" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2965" columnIds="2961" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="136" id="2966" name="MTMP_supporting_structural_variation" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2967" name="outer_end" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2968" name="copy_number" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2969" name="variation_name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2970" name="structural_variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2971" name="seq_region_name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2972" name="seq_region_end" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2973" name="supporting_structural_variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2974" name="clinical_significance" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2975" name="strain_name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2976" name="seq_region_strand" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2977" name="class_name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2978" name="inner_start" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2979" name="outer_start" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2980" name="inner_end" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2981" name="sample_name" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2982" name="seq_region_start" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<foreignKey id="2983" columnIds="2970" status="INFERRED" visibleModified="false"/>
+		</table>
+		<table uniqueId="153" id="2984" name="MTMP_variation_set_structural_variation" ignore="false" inSchemaPartition="variation_species_list">
+			<column id="2985" name="variation_set_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<column id="2986" name="structural_variation_id" visibleModified="false" inSchemaPartition="variation_species_list"/>
+			<primaryKey id="2987" columnIds="2986,2985" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2988" columnIds="2985" status="INFERRED" visibleModified="false"/>
+			<foreignKey id="2989" columnIds="2986" status="INFERRED" visibleModified="false"/>
+		</table>
+		<relation id="2990" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2443" secondKeyId="2594" status="INFERRED" visibleModified="false"/>
+		<relation id="2991" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2428" secondKeyId="2401" status="INFERRED" visibleModified="false"/>
+		<relation id="2992" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2747" secondKeyId="2692" status="INFERRED" visibleModified="false"/>
+		<relation id="2993" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2893" secondKeyId="2909" status="INFERRED" visibleModified="false"/>
+		<relation id="2994" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2428" secondKeyId="2414" status="INFERRED" visibleModified="false"/>
+		<relation id="2995" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2501" secondKeyId="2685" status="INFERRED" visibleModified="false"/>
+		<relation id="2996" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2929" secondKeyId="2939" status="INFERRED" visibleModified="false"/>
+		<relation id="2997" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2659" secondKeyId="2896" status="INFERRED" visibleModified="false"/>
+		<relation id="2998" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2480" secondKeyId="2830" status="INFERRED" visibleModified="false"/>
+		<relation id="2999" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2588" secondKeyId="2624" status="INFERRED" visibleModified="false"/>
+		<relation id="3000" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2400" secondKeyId="2486" status="INFERRED" visibleModified="false"/>
+		<relation id="3001" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2443" secondKeyId="2703" status="INFERRED" visibleModified="false"/>
+		<relation id="3002" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2836" secondKeyId="2916" status="INFERRED" visibleModified="false"/>
+		<relation id="3003" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2443" secondKeyId="2901" status="INFERRED" visibleModified="false"/>
+		<relation id="3004" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2428" secondKeyId="2933" status="INFERRED" visibleModified="false"/>
+		<relation id="3005" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2443" secondKeyId="2778" status="INFERRED" visibleModified="false"/>
+		<relation id="3006" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2603" secondKeyId="2734" status="INFERRED" visibleModified="false"/>
+		<relation id="3007" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2501" secondKeyId="2578" status="INFERRED" visibleModified="false"/>
+		<relation id="3008" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2387" secondKeyId="2883" status="INFERRED" visibleModified="false"/>
+		<relation id="3009" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2443" secondKeyId="2622" status="INFERRED" visibleModified="false"/>
+		<relation id="3010" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2443" secondKeyId="2523" status="INFERRED" visibleModified="false"/>
+		<relation id="3011" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2879" secondKeyId="2806" status="INFERRED" visibleModified="false"/>
+		<relation id="3012" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2893" secondKeyId="2515" status="INFERRED" visibleModified="false"/>
+		<relation id="3013" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2893" secondKeyId="2741" status="INFERRED" visibleModified="false"/>
+		<relation id="3014" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2747" secondKeyId="2930" status="INFERRED" visibleModified="false"/>
+		<relation id="3015" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2747" secondKeyId="2882" status="INFERRED" visibleModified="false"/>
+		<relation id="3016" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2588" secondKeyId="2516" status="INFERRED" visibleModified="false"/>
+		<relation id="3017" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2893" secondKeyId="2524" status="INFERRED" visibleModified="false"/>
+		<relation id="3018" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2443" secondKeyId="2955" status="INFERRED" visibleModified="false"/>
+		<relation id="3019" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2879" secondKeyId="2639" status="INFERRED" visibleModified="false"/>
+		<relation id="3020" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2659" secondKeyId="2572" status="INFERRED" visibleModified="false"/>
+		<relation id="3021" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2879" secondKeyId="2677" status="INFERRED" visibleModified="false"/>
+		<relation id="3022" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2443" secondKeyId="2848" status="INFERRED" visibleModified="false"/>
+		<relation id="3023" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2707" secondKeyId="2812" status="INFERRED" visibleModified="false"/>
+		<relation id="3024" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2443" secondKeyId="2491" status="INFERRED" visibleModified="false"/>
+		<relation id="3025" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2510" secondKeyId="2760" status="INFERRED" visibleModified="false"/>
+		<relation id="3026" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2954" secondKeyId="2667" status="INFERRED" visibleModified="false"/>
+		<relation id="3027" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2747" secondKeyId="2532" status="INFERRED" visibleModified="false"/>
+		<relation id="3028" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2400" secondKeyId="2989" status="INFERRED" visibleModified="false"/>
+		<relation id="3029" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2545" secondKeyId="2589" status="INFERRED" visibleModified="false"/>
+		<relation id="3030" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2443" secondKeyId="2813" status="INFERRED" visibleModified="false"/>
+		<relation id="3031" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2819" secondKeyId="2684" status="INFERRED" visibleModified="false"/>
+		<relation id="3032" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2387" secondKeyId="2854" status="INFERRED" visibleModified="false"/>
+		<relation id="3033" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2659" secondKeyId="2931" status="INFERRED" visibleModified="false"/>
+		<relation id="3034" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2588" secondKeyId="2413" status="INFERRED" visibleModified="false"/>
+		<relation id="3035" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2819" secondKeyId="2938" status="INFERRED" visibleModified="false"/>
+		<relation id="3036" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2443" secondKeyId="2540" status="INFERRED" visibleModified="false"/>
+		<relation id="3037" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2428" secondKeyId="2849" status="INFERRED" visibleModified="false"/>
+		<relation id="3038" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2836" secondKeyId="2932" status="INFERRED" visibleModified="false"/>
+		<relation id="3039" cardinality="M(b)" originalCardinality="M(b)" firstKeyId="2880" secondKeyId="2697" status="HANDMADE" visibleModified="false"/>
+		<relation id="3040" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2766" secondKeyId="2497" status="INFERRED" visibleModified="false"/>
+		<relation id="3041" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2470" secondKeyId="2748" status="INFERRED" visibleModified="false"/>
+		<relation id="3042" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2443" secondKeyId="2880" status="INFERRED" visibleModified="false"/>
+		<relation id="3043" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2387" secondKeyId="2571" status="INFERRED" visibleModified="false"/>
+		<relation id="3044" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2893" secondKeyId="2533" status="INFERRED" visibleModified="false"/>
+		<relation id="3045" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2428" secondKeyId="2569" status="INFERRED" visibleModified="false"/>
+		<relation id="3046" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2443" secondKeyId="2496" status="INFERRED" visibleModified="false"/>
+		<relation id="3047" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2400" secondKeyId="2908" status="INFERRED" visibleModified="false"/>
+		<relation id="3048" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2428" secondKeyId="2742" status="INFERRED" visibleModified="false"/>
+		<relation id="3049" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2819" secondKeyId="2767" status="INFERRED" visibleModified="false"/>
+		<relation id="3050" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2893" secondKeyId="2965" status="INFERRED" visibleModified="false"/>
+		<relation id="3051" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2428" secondKeyId="2761" status="INFERRED" visibleModified="false"/>
+		<relation id="3052" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2893" secondKeyId="2693" status="INFERRED" visibleModified="false"/>
+		<relation id="3053" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2443" secondKeyId="2829" status="INFERRED" visibleModified="false"/>
+		<relation id="3054" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2470" secondKeyId="2944" status="INFERRED" visibleModified="false"/>
+		<relation id="3055" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2387" secondKeyId="2485" status="INFERRED" visibleModified="false"/>
+		<relation id="3056" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2443" secondKeyId="2964" status="INFERRED" visibleModified="false"/>
+		<relation id="3057" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2428" secondKeyId="2660" status="INFERRED" visibleModified="false"/>
+		<relation id="3058" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2707" secondKeyId="2462" status="INFERRED" visibleModified="false"/>
+		<relation id="3059" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2766" secondKeyId="2753" status="INFERRED" visibleModified="false"/>
+		<relation id="3060" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2879" secondKeyId="2381" status="INFERRED" visibleModified="false"/>
+		<relation id="3061" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2733" secondKeyId="2623" status="INFERRED" visibleModified="false"/>
+		<relation id="3062" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2879" secondKeyId="2646" status="INFERRED" visibleModified="false"/>
+		<relation id="3063" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2603" secondKeyId="2956" status="INFERRED" visibleModified="false"/>
+		<relation id="3064" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2443" secondKeyId="2698" status="INFERRED" visibleModified="false"/>
+		<relation id="3065" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2400" secondKeyId="2599" status="INFERRED" visibleModified="false"/>
+		<relation id="3066" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2387" secondKeyId="2988" status="INFERRED" visibleModified="false"/>
+		<relation id="3067" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2747" secondKeyId="2570" status="INFERRED" visibleModified="false"/>
+		<relation id="3068" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2387" secondKeyId="2894" status="INFERRED" visibleModified="false"/>
+		<relation id="3069" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2824" secondKeyId="2511" status="INFERRED" visibleModified="false"/>
+		<relation id="3070" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2707" secondKeyId="2645" status="INFERRED" visibleModified="false"/>
+		<relation id="3071" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2400" secondKeyId="2983" status="INFERRED" visibleModified="false"/>
+		<relation id="3072" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2428" secondKeyId="2444" status="INFERRED" visibleModified="false"/>
+		<relation id="3073" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2400" secondKeyId="2461" status="INFERRED" visibleModified="false"/>
+		<relation id="3074" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2510" secondKeyId="2895" status="INFERRED" visibleModified="false"/>
+		<relation id="3075" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2879" secondKeyId="2371" status="INFERRED" visibleModified="false"/>
+		<relation id="3076" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2659" secondKeyId="2402" status="INFERRED" visibleModified="false"/>
+		<relation id="3077" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2707" secondKeyId="2666" status="INFERRED" visibleModified="false"/>
+		<relation id="3078" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2879" secondKeyId="2726" status="INFERRED" visibleModified="false"/>
+		<relation id="3079" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2400" secondKeyId="2568" status="INFERRED" visibleModified="false"/>
+		<relation id="3080" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2588" secondKeyId="2779" status="INFERRED" visibleModified="false"/>
+		<relation id="3081" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2588" secondKeyId="2957" status="INFERRED" visibleModified="false"/>
+		<relation id="3082" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2443" secondKeyId="2855" status="INFERRED" visibleModified="false"/>
+		<relation id="3083" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2387" secondKeyId="2593" status="INFERRED" visibleModified="false"/>
+		<relation id="3084" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2428" secondKeyId="2881" status="INFERRED" visibleModified="false"/>
+		<relation id="3085" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="2621" secondKeyId="2780" status="INFERRED" visibleModified="false"/>
+	</jdbcSchema>
+	<relation id="3086" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="447" secondKeyId="2727" status="HANDMADE" visibleModified="false"/>
+	<relation id="3087" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="447" secondKeyId="862" status="HANDMADE" visibleModified="false"/>
+	<relation id="3088" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="248" secondKeyId="2455" status="HANDMADE" visibleModified="false"/>
+	<relation id="3089" cardinality="M(a)" originalCardinality="M(a)" firstKeyId="1818" secondKeyId="218" status="HANDMADE" visibleModified="false"/>
+	<dataset name="%NAME%" centralTableId="226" optimiser="COLUMN_BOOL_NULL_INHERIT" invisible="false" masked="false" hideMasked="true" indexOptimiser="false">
+		<subclassRelation relationId="729"/>
+		<compoundRelation relationId="746" n="2" parallel="true"/>
+		<compoundRelation relationId="3086" n="2" parallel="true"/>
+		<subclassRelation relationId="752"/>
+		<compoundRelation relationId="775" n="2" parallel="true"/>
+		<compoundRelation relationId="778" n="2" parallel="true"/>
+		<compoundRelation relationId="814" n="2" parallel="true"/>
+		<compoundRelation relationId="3086" n="2" parallel="true"/>
+		<maskedTable tableKey="gene__misc_feature"/>
+		<renamedTable tableKey="gene__misc_feature" newName="misc_feature"/>
+		<renamedColumn tableKey="gene__misc_feature" colKey="1.36.0.attrib_type_id" newName="attrib_type_id_1036"/>
+		<renamedColumn tableKey="gene__misc_feature" colKey="1.36.0.value" newName="value_1036"/>
+		<renamedColumn tableKey="gene__misc_feature" colKey="1.6.0.name" newName="name_106"/>
+		<renamedColumn tableKey="gene__misc_feature" colKey="1.37.0.misc_feature_id" newName="misc_feature_id_1037"/>
+		<renamedColumn tableKey="gene__misc_feature" colKey="1.37.0.seq_region_end" newName="seq_region_end_1037"/>
+		<renamedColumn tableKey="gene__misc_feature" colKey="1.6.0.description" newName="description_106"/>
+		<renamedColumn tableKey="gene__misc_feature" colKey="1.6.0.code" newName="code_106"/>
+		<maskedColumn tableKey="gene__misc_feature" colKey="seq_region_id_1020"/>
+		<renamedColumn tableKey="gene__misc_feature" colKey="1.37.0.seq_region_strand" newName="seq_region_strand_1037"/>
+		<renamedColumn tableKey="gene__misc_feature" colKey="1.37.0.seq_region_start" newName="seq_region_start_1037"/>
+		<renamedTable tableKey="gene" newName="gene"/>
+		<distinctRows tableKey="gene"/>
+		<indexedColumn tableKey="gene" colKey="1.20.0.biotype"/>
+		<renamedColumn tableKey="gene" colKey="1.20.0.biotype" newName="biotype_1020"/>
+		<renamedColumn tableKey="gene" colKey="1.20.0.version" newName="version_1020"/>
+		<renamedColumn tableKey="gene" colKey="1.20.0.seq_region_strand" newName="seq_region_strand_1020"/>
+		<renamedColumn tableKey="gene" colKey="1.74.0.display_label" newName="display_label_1074"/>
+		<renamedColumn tableKey="gene" colKey="1.20.0.description" newName="description_1020"/>
+		<renamedColumn tableKey="gene" colKey="1.27.0.band" newName="band_1027"/>
+		<maskedColumn tableKey="gene" colKey="1.18.0.db_release"/>
+		<renamedColumn tableKey="gene" colKey="1.18.0.db_release" newName="db_release_1018"/>
+		<maskedColumn tableKey="gene" colKey="1.22.0.attrib_type_id"/>
+		<renamedColumn tableKey="gene" colKey="1.22.0.attrib_type_id" newName="attrib_type_id_1022"/>
+		<maskedColumn tableKey="gene" colKey="1.20.0.created_date"/>
+		<renamedColumn tableKey="gene" colKey="1.20.0.created_date" newName="created_date_1020"/>
+		<maskedColumn tableKey="gene" colKey="1.59.0.length"/>
+		<renamedColumn tableKey="gene" colKey="1.59.0.length" newName="length_1059"/>
+		<maskedColumn tableKey="gene" colKey="1.18.0.secondary_db_name"/>
+		<renamedColumn tableKey="gene" colKey="1.18.0.secondary_db_name" newName="secondary_db_name_1018"/>
+		<indexedColumn tableKey="gene" colKey="1.20.0.stable_id"/>
+		<renamedColumn tableKey="gene" colKey="1.20.0.stable_id" newName="stable_id_1023"/>
+		<maskedColumn tableKey="gene" colKey="1.20.0.analysis_id"/>
+		<renamedColumn tableKey="gene" colKey="1.20.0.analysis_id" newName="analysis_id_1020"/>
+		<maskedColumn tableKey="gene" colKey="1.18.0.status"/>
+		<renamedColumn tableKey="gene" colKey="1.18.0.status" newName="status_1018"/>
+		<maskedColumn tableKey="gene" colKey="1.74.0.external_db_id"/>
+		<renamedColumn tableKey="gene" colKey="1.74.0.external_db_id" newName="external_db_id_1074"/>
+		<maskedColumn tableKey="gene" colKey="1.18.0.db_name"/>
+		<renamedColumn tableKey="gene" colKey="1.18.0.db_name" newName="db_name_1018"/>
+		<indexedColumn tableKey="gene" colKey="1.59.0.name"/>
+		<renamedColumn tableKey="gene" colKey="1.59.0.name" newName="name_1059"/>
+		<maskedColumn tableKey="gene" colKey="1.20.0.canonical_transcript_id"/>
+		<renamedColumn tableKey="gene" colKey="1.20.0.canonical_transcript_id" newName="canonical_transcript_id_1020"/>
+		<maskedColumn tableKey="gene" colKey="1.20.0.is_current"/>
+		<renamedColumn tableKey="gene" colKey="1.20.0.is_current" newName="is_current_1020"/>
+		<maskedColumn tableKey="gene" colKey="1.20.0.seq_region_id"/>
+		<renamedColumn tableKey="gene" colKey="1.20.0.seq_region_id" newName="seq_region_id_1020"/>
+		<renamedColumn tableKey="gene" colKey="1.20.0.seq_region_end" newName="seq_region_end_1020"/>
+		<maskedColumn tableKey="gene" colKey="1.20.0.display_xref_id"/>
+		<renamedColumn tableKey="gene" colKey="1.20.0.display_xref_id" newName="display_xref_id_1020"/>
+		<maskedColumn tableKey="gene" colKey="1.74.0.info_text"/>
+		<renamedColumn tableKey="gene" colKey="1.74.0.info_text" newName="info_text_1074"/>
+		<maskedColumn tableKey="gene" colKey="1.74.0.version"/>
+		<renamedColumn tableKey="gene" colKey="1.74.0.version" newName="version_1074"/>
+		<maskedColumn tableKey="gene" colKey="1.59.0.coord_system_id"/>
+		<renamedColumn tableKey="gene" colKey="1.59.0.coord_system_id" newName="coord_system_id_1059"/>
+		<renamedColumn tableKey="gene" colKey="1.20.0.seq_region_start" newName="seq_region_start_1020"/>
+		<maskedColumn tableKey="gene" colKey="1.74.0.description"/>
+		<renamedColumn tableKey="gene" colKey="1.74.0.description" newName="description_1074"/>
+		<indexedColumn tableKey="gene" colKey="1.20.0.source"/>
+		<renamedColumn tableKey="gene" colKey="1.20.0.source" newName="source_1020"/>
+		<maskedColumn tableKey="gene" colKey="1.27.0.seq_region_start"/>
+		<renamedColumn tableKey="gene" colKey="1.27.0.seq_region_start" newName="seq_region_start_1027"/>
+		<maskedColumn tableKey="gene" colKey="1.18.0.secondary_db_table"/>
+		<renamedColumn tableKey="gene" colKey="1.18.0.secondary_db_table" newName="secondary_db_table_1018"/>
+		<maskedColumn tableKey="gene" colKey="1.27.0.stain"/>
+		<renamedColumn tableKey="gene" colKey="1.27.0.stain" newName="stain_1027"/>
+		<maskedColumn tableKey="gene" colKey="1.74.0.dbprimary_acc"/>
+		<renamedColumn tableKey="gene" colKey="1.74.0.dbprimary_acc" newName="dbprimary_acc_1074"/>
+		<maskedColumn tableKey="gene" colKey="1.18.0.priority"/>
+		<renamedColumn tableKey="gene" colKey="1.18.0.priority" newName="priority_1018"/>
+		<maskedColumn tableKey="gene" colKey="1.27.0.seq_region_end"/>
+		<renamedColumn tableKey="gene" colKey="1.27.0.seq_region_end" newName="seq_region_end_1027"/>
+		<renamedColumn tableKey="gene" colKey="1.22.0.value" newName="value_1022"/>
+		<renamedColumn tableKey="gene" colKey="1.18.0.db_display_name" newName="db_display_name_1018"/>
+		<maskedColumn tableKey="gene" colKey="1.18.0.type"/>
+		<renamedColumn tableKey="gene" colKey="1.18.0.type" newName="type_1018"/>
+		<maskedColumn tableKey="gene" colKey="1.27.0.karyotype_id"/>
+		<renamedColumn tableKey="gene" colKey="1.27.0.karyotype_id" newName="karyotype_id_1027"/>
+		<renamedColumn tableKey="gene" colKey="1.20.0.gene_id" newName="gene_id_1020_key"/>
+		<maskedColumn tableKey="gene" colKey="1.74.0.info_type"/>
+		<renamedColumn tableKey="gene" colKey="1.74.0.info_type" newName="info_type_1074"/>
+		<maskedColumn tableKey="gene" colKey="1.18.0.description"/>
+		<renamedColumn tableKey="gene" colKey="1.18.0.description" newName="description_1018"/>
+		<maskedColumn tableKey="gene" colKey="1.20.0.modified_date"/>
+		<renamedColumn tableKey="gene" colKey="1.20.0.modified_date" newName="modified_date_1020"/>
+		<maskedRelation tableKey="gene" relationId="714"/>
+		<maskedRelation tableKey="gene" relationId="723"/>
+		<maskedRelation tableKey="gene" relationId="728"/>
+		<maskedRelation tableKey="gene" relationId="732"/>
+		<maskedRelation tableKey="gene" relationId="3089"/>
+		<maskedRelation tableKey="gene" relationId="741"/>
+		<restrictedRelation tableKey="gene" relationId="744" index="0" leftAliasColumnIds="83,84" leftAliasNames="firstCol2,firstCol1" rightAliasColumnIds="238,230,242" rightAliasNames="secondCol3,secondCol2,secondCol1" expression="((:secondCol1&gt;=:firstCol1 and :secondCol1&lt;=:firstCol2 and :secondCol3=1) or (:secondCol2&gt;=:firstCol1 and :secondCol2&lt;=:firstCol2 and :secondCol3=-1))"/>
+		<maskedRelation tableKey="gene" relationId="759"/>
+		<maskedRelation tableKey="gene" relationId="762"/>
+		<maskedRelation tableKey="gene" relationId="763"/>
+		<maskedRelation tableKey="gene" relationId="764"/>
+		<maskedRelation tableKey="gene" relationId="768"/>
+		<maskedRelation tableKey="gene" relationId="782"/>
+		<maskedRelation tableKey="gene" relationId="784"/>
+		<maskedRelation tableKey="gene" relationId="785"/>
+		<maskedRelation tableKey="gene" relationId="789"/>
+		<maskedRelation tableKey="gene" relationId="791"/>
+		<maskedRelation tableKey="gene" relationId="795"/>
+		<maskedRelation tableKey="gene" relationId="798"/>
+		<maskedRelation tableKey="gene" relationId="800"/>
+		<maskedRelation tableKey="gene" relationId="807"/>
+		<maskedRelation tableKey="gene" relationId="812"/>
+		<maskedRelation tableKey="gene" relationId="816"/>
+		<maskedRelation tableKey="gene" relationId="817"/>
+		<restrictedTable tableKey="gene" tableId="226" aliasColumnIds="231" aliasNames="col1" expression=":col1 != &quot;LRG database&quot;"/>
+		<restrictedTable tableKey="gene" tableId="483" aliasColumnIds="484" aliasNames="col1" expression=":col1=&quot;GeneGC&quot;"/>
+		<restrictedTable tableKey="gene" tableId="707" aliasColumnIds="708" aliasNames="col1" expression=":col1 = 142"/>
+		<maskedRelation tableKey="gene" relationId="3089"/>
+		<maskedRelation tableKey="gene" relationId="2348"/>
+		<renamedTable tableKey="transcript__MTMP_probestuff_helper" newName="eFG"/>
+		<maskedColumn tableKey="transcript__MTMP_probestuff_helper" colKey="11.56.0.is_probeset_array"/>
+		<renamedColumn tableKey="transcript__MTMP_probestuff_helper" colKey="11.56.0.is_probeset_array" newName="is_probeset_array_11056"/>
+		<renamedColumn tableKey="transcript__MTMP_probestuff_helper" colKey="11.56.0.display_label" newName="display_label_11056"/>
+		<maskedColumn tableKey="transcript__MTMP_probestuff_helper" colKey="11.56.0.array_name"/>
+		<renamedColumn tableKey="transcript__MTMP_probestuff_helper" colKey="11.56.0.array_name" newName="array_name_11056"/>
+		<maskedColumn tableKey="transcript__MTMP_probestuff_helper" colKey="11.56.0.array_vendor_and_name"/>
+		<renamedColumn tableKey="transcript__MTMP_probestuff_helper" colKey="11.56.0.array_vendor_and_name" newName="array_vendor_and_name_11056"/>
+		<renamedTable tableKey="translation__protein_feature" newName="protein_feature"/>
+		<distinctRows tableKey="translation__protein_feature"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.48.0.perc_ident"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.48.0.perc_ident" newName="perc_ident_1048"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.48.0.external_data"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.48.0.external_data" newName="external_data_1048"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.2.0.created"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.2.0.created" newName="created_102"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.48.0.cigar_line"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.48.0.cigar_line" newName="cigar_line_1048"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.48.0.align_type"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.48.0.align_type" newName="align_type_1048"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.48.0.analysis_id"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.48.0.analysis_id" newName="analysis_id_1048"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.2.0.logic_name"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.2.0.logic_name" newName="logic_name_102"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.48.0.protein_feature_id"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.48.0.protein_feature_id" newName="protein_feature_id_1048"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.2.0.gff_feature"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.2.0.gff_feature" newName="gff_feature_102"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.2.0.module_version"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.2.0.module_version" newName="module_version_102"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.48.0.score"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.48.0.score" newName="score_1048"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.2.0.db_file"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.2.0.db_file" newName="db_file_102"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.48.0.hit_start"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.48.0.hit_start" newName="hit_start_1048"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.2.0.module"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.2.0.module" newName="module_102"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.48.0.seq_start" newName="seq_start_1048"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.48.0.hit_description"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.48.0.hit_description" newName="hit_description_1048"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.2.0.program_version"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.2.0.program_version" newName="program_version_102"/>
+		<indexedColumn tableKey="translation__protein_feature" colKey="1.48.0.hit_name"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.48.0.hit_name" newName="hit_name_1048"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.2.0.db_version"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.2.0.db_version" newName="db_version_102"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.2.0.gff_source"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.2.0.gff_source" newName="gff_source_102"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.2.0.parameters"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.2.0.parameters" newName="parameters_102"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.48.0.seq_end" newName="seq_end_1048"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.2.0.program_file"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.2.0.program_file" newName="program_file_102"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.48.0.hit_end"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.48.0.hit_end" newName="hit_end_1048"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.48.0.evalue"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.48.0.evalue" newName="evalue_1048"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.2.0.program"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.2.0.program" newName="program_102"/>
+		<maskedColumn tableKey="translation__protein_feature" colKey="1.2.0.db"/>
+		<renamedColumn tableKey="translation__protein_feature" colKey="1.2.0.db" newName="db_102"/>
+		<maskedRelation tableKey="translation__protein_feature" relationId="743"/>
+		<maskedRelation tableKey="translation__protein_feature" relationId="818"/>
+		<renamedTable tableKey="translation__protein_feature_1" newName="interpro"/>
+		<distinctRows tableKey="translation__protein_feature_1"/>
+		<maskedColumn tableKey="translation__protein_feature_1" colKey="1.74.0.xref_id"/>
+		<renamedColumn tableKey="translation__protein_feature_1" colKey="1.74.0.xref_id" newName="xref_id_1074"/>
+		<maskedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.perc_ident"/>
+		<renamedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.perc_ident" newName="perc_ident_1048"/>
+		<indexedColumn tableKey="translation__protein_feature_1" colKey="1.26.0.interpro_ac"/>
+		<renamedColumn tableKey="translation__protein_feature_1" colKey="1.26.0.interpro_ac" newName="interpro_ac_1026"/>
+		<maskedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.external_data"/>
+		<renamedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.external_data" newName="external_data_1048"/>
+		<maskedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.hit_name"/>
+		<renamedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.hit_name" newName="hit_name_1048"/>
+		<maskedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.cigar_line"/>
+		<renamedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.cigar_line" newName="cigar_line_1048"/>
+		<maskedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.align_type"/>
+		<renamedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.align_type" newName="align_type_1048"/>
+		<renamedColumn tableKey="translation__protein_feature_1" colKey="1.74.0.display_label" newName="display_label_1074"/>
+		<maskedColumn tableKey="translation__protein_feature_1" colKey="1.74.0.info_text"/>
+		<renamedColumn tableKey="translation__protein_feature_1" colKey="1.74.0.info_text" newName="info_text_1074"/>
+		<maskedColumn tableKey="translation__protein_feature_1" colKey="1.74.0.version"/>
+		<renamedColumn tableKey="translation__protein_feature_1" colKey="1.74.0.version" newName="version_1074"/>
+		<maskedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.analysis_id"/>
+		<renamedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.analysis_id" newName="analysis_id_1048"/>
+		<renamedColumn tableKey="translation__protein_feature_1" colKey="1.74.0.description" newName="description_1074"/>
+		<maskedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.protein_feature_id"/>
+		<renamedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.protein_feature_id" newName="protein_feature_id_1048"/>
+		<renamedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.seq_end" newName="seq_end_1048"/>
+		<maskedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.hit_end"/>
+		<renamedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.hit_end" newName="hit_end_1048"/>
+		<maskedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.score"/>
+		<renamedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.score" newName="score_1048"/>
+		<maskedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.evalue"/>
+		<renamedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.evalue" newName="evalue_1048"/>
+		<maskedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.hit_start"/>
+		<renamedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.hit_start" newName="hit_start_1048"/>
+		<maskedColumn tableKey="translation__protein_feature_1" colKey="1.74.0.info_type"/>
+		<renamedColumn tableKey="translation__protein_feature_1" colKey="1.74.0.info_type" newName="info_type_1074"/>
+		<renamedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.seq_start" newName="seq_start_1048"/>
+		<maskedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.hit_description"/>
+		<renamedColumn tableKey="translation__protein_feature_1" colKey="1.48.0.hit_description" newName="hit_description_1048"/>
+		<maskedColumn tableKey="translation__protein_feature_1" colKey="1.74.0.external_db_id"/>
+		<renamedColumn tableKey="translation__protein_feature_1" colKey="1.74.0.external_db_id" newName="external_db_id_1074"/>
+		<maskedRelation tableKey="translation__protein_feature_1" relationId="723"/>
+		<maskedRelation tableKey="translation__protein_feature_1" relationId="727"/>
+		<maskedRelation tableKey="translation__protein_feature_1" relationId="728"/>
+		<maskedRelation tableKey="translation__protein_feature_1" relationId="732"/>
+		<maskedRelation tableKey="translation__protein_feature_1" relationId="3089"/>
+		<maskedRelation tableKey="translation__protein_feature_1" relationId="739"/>
+		<maskedRelation tableKey="translation__protein_feature_1" relationId="762"/>
+		<maskedRelation tableKey="translation__protein_feature_1" relationId="782"/>
+		<maskedRelation tableKey="translation__protein_feature_1" relationId="784"/>
+		<maskedRelation tableKey="translation__protein_feature_1" relationId="789"/>
+		<maskedRelation tableKey="translation__protein_feature_1" relationId="795"/>
+		<maskedRelation tableKey="translation__protein_feature_1" relationId="798"/>
+		<maskedRelation tableKey="translation__protein_feature_1" relationId="800"/>
+		<maskedRelation tableKey="translation__protein_feature_1" relationId="807"/>
+		<maskedRelation tableKey="translation__protein_feature_1" relationId="808"/>
+		<maskedRelation tableKey="translation__protein_feature_1" relationId="812"/>
+		<maskedRelation tableKey="translation__protein_feature_1" relationId="816"/>
+		<maskedRelation tableKey="translation__protein_feature_1" relationId="817"/>
+		<maskedRelation tableKey="translation__protein_feature_1" relationId="819"/>
+		<maskedRelation tableKey="translation__protein_feature_1" relationId="3089"/>
+		<maskedRelation tableKey="translation__protein_feature_1" relationId="2348"/>
+		<renamedTable tableKey="gene__MTMP_phenotype" newName="phenotype"/>
+		<renamedColumn tableKey="gene__MTMP_phenotype" colKey="2.133.0.strain_name" newName="strain_name_20125"/>
+		<indexedColumn tableKey="gene__MTMP_phenotype" colKey="2.133.0.source"/>
+		<renamedColumn tableKey="gene__MTMP_phenotype" colKey="2.133.0.source" newName="source_20125"/>
+		<indexedColumn tableKey="gene__MTMP_phenotype" colKey="2.133.0.description"/>
+		<renamedColumn tableKey="gene__MTMP_phenotype" colKey="2.133.0.description" newName="description_20125"/>
+		<renamedColumn tableKey="gene__MTMP_phenotype" colKey="2.133.0.p_value" newName="p_value_20125"/>
+		<renamedColumn tableKey="gene__MTMP_phenotype" colKey="2.133.0.external_id" newName="external_id_20125"/>
+		<maskedColumn tableKey="gene__MTMP_phenotype" colKey="2.133.0.mtmp_phenotype_id"/>
+		<renamedColumn tableKey="gene__MTMP_phenotype" colKey="2.133.0.mtmp_phenotype_id" newName="mtmp_phenotype_id_20125"/>
+		<renamedColumn tableKey="gene__MTMP_phenotype" colKey="2.133.0.strain_gender" newName="strain_gender_20125"/>
+		<renamedTable tableKey="translation__object_xref_1" newName="ontology"/>
+		<tableHideMasked tableKey="translation__object_xref_1"/>
+		<distinctRows tableKey="translation__object_xref_1"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="1.74.0.xref_id"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.74.0.xref_id" newName="xref_id_1074"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="1.74.0.display_label"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.74.0.display_label" newName="display_label_1074"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="1.18.0.db_release"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.18.0.db_release" newName="db_release_1018"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="1.40.0.ensembl_object_type"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="1.40.0.object_xref_id"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="10.6.0.is_root" newName="is_root_1006"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="10.6.0.subsets"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="10.6.0.subsets" newName="subsets_1006"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="10.6.0.is_obsolete"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="10.6.0.is_obsolete" newName="is_obsolete_1006"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="1.18.0.secondary_db_name"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.18.0.secondary_db_name" newName="secondary_db_name_1018"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="10.6.0.term_id"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="10.6.0.term_id" newName="term_id_1006"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.40.0.ensembl_id" newName="translation_id_1068_key"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="1.18.0.external_db_id"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.18.0.external_db_id" newName="external_db_id_1018"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="1.18.0.status"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.18.0.status" newName="status_1018"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="1.18.0.db_name"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.18.0.db_name" newName="db_name_1018"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="10.6.0.ontology_id"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="10.6.0.ontology_id" newName="ontology_id_1006"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="1.40.0.linkage_annotation"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.40.0.linkage_annotation" newName="linkage_annotation_1040"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="10.3.0.name"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="10.3.0.name" newName="name_1003"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="1.74.0.info_text"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.74.0.info_text" newName="info_text_1074"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="1.74.0.version"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.74.0.version" newName="version_1074"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="10.6.0.name" newName="name_1006"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="10.3.0.data_version"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="10.3.0.data_version" newName="data_version_1003"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="1.74.0.description"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.74.0.description" newName="description_1074"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="1.18.0.secondary_db_table"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.18.0.secondary_db_table" newName="secondary_db_table_1018"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="1.40.0.analysis_id"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.40.0.analysis_id" newName="analysis_id_1040"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="10.3.0.namespace" newName="namespace_1003"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="10.6.0.definition" newName="definition_1006"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="1.18.0.priority"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.18.0.priority" newName="priority_1018"/>
+		<indexedColumn tableKey="translation__object_xref_1" colKey="1.74.0.dbprimary_acc"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.74.0.dbprimary_acc" newName="dbprimary_acc_1074"/>
+		<indexedColumn tableKey="translation__object_xref_1" colKey="1.24.0.linkage_type"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.24.0.linkage_type" newName="linkage_type_1024"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="10.6.0.iri"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="10.6.0.iri" newName="iri_1006"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="10.3.0.title"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="10.3.0.title" newName="title_1003"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="1.18.0.db_display_name"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.18.0.db_display_name" newName="db_display_name_1018"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="1.18.0.type"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.18.0.type" newName="type_1018"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="1.74.0.info_type"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.74.0.info_type" newName="info_type_1074"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="1.24.0.source_xref_id"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.24.0.source_xref_id" newName="source_xref_id_1024"/>
+		<maskedColumn tableKey="translation__object_xref_1" colKey="1.18.0.description"/>
+		<renamedColumn tableKey="translation__object_xref_1" colKey="1.18.0.description" newName="description_1018"/>
+		<alternativeJoin tableKey="translation__object_xref_1" relationId="727"/>
+		<maskedRelation tableKey="translation__object_xref_1" relationId="732"/>
+		<alternativeJoin tableKey="translation__object_xref_1" relationId="3089"/>
+		<alternativeJoin tableKey="translation__object_xref_1" relationId="755"/>
+		<alternativeJoin tableKey="translation__object_xref_1" relationId="786"/>
+		<transformStart tableKey="translation__object_xref_1" tableId="342"/>
+		<restrictedTable tableKey="translation__object_xref_1" tableId="677" aliasColumnIds="678,682" aliasNames="col2,col1" expression=":col1='Translation' AND (:col2!='NOT' OR :col2 IS NULL)"/>
+		<alternativeJoin tableKey="translation__object_xref_1" relationId="3089"/>
+		<alternativeJoin tableKey="translation__object_xref_1" relationId="2348"/>
+		<renamedTable tableKey="transcript__object_xref_1" newName="ontology"/>
+		<tableHideMasked tableKey="transcript__object_xref_1"/>
+		<distinctRows tableKey="transcript__object_xref_1"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.74.0.xref_id"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.74.0.xref_id" newName="xref_id_1074"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.19.0.synonym"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.19.0.synonym" newName="synonym_1019"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.74.0.display_label"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.74.0.display_label" newName="display_label_1074"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.18.0.db_release"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.18.0.db_release" newName="db_release_1018"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.40.0.ensembl_object_type"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.40.0.object_xref_id"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="10.6.0.is_root" newName="is_root_1006"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="10.6.0.subsets"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="10.6.0.subsets" newName="subsets_1006"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="10.6.0.is_obsolete"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="10.6.0.is_obsolete" newName="is_obsolete_1006"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.18.0.secondary_db_name"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.18.0.secondary_db_name" newName="secondary_db_name_1018"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="10.6.0.term_id"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="10.6.0.term_id" newName="term_id_1006"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.40.0.ensembl_id" newName="transcript_id_1064_key"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.18.0.external_db_id"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.18.0.external_db_id" newName="external_db_id_1018"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.18.0.status"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.18.0.status" newName="status_1018"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.18.0.db_name"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.18.0.db_name" newName="db_name_1018"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="10.6.0.ontology_id"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="10.6.0.ontology_id" newName="ontology_id_1006"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.40.0.linkage_annotation"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.40.0.linkage_annotation" newName="linkage_annotation_1040"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="10.3.0.name"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="10.3.0.name" newName="name_1003"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.74.0.info_text"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.74.0.info_text" newName="info_text_1074"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.74.0.version"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.74.0.version" newName="version_1074"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="10.6.0.name" newName="name_1006"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="10.3.0.data_version"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="10.3.0.data_version" newName="data_version_1003"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.74.0.description"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.74.0.description" newName="description_1074"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.18.0.secondary_db_table"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.18.0.secondary_db_table" newName="secondary_db_table_1018"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.40.0.analysis_id"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.40.0.analysis_id" newName="analysis_id_1040"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="10.3.0.namespace" newName="namespace_1003"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="10.6.0.definition" newName="definition_1006"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.18.0.priority"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.18.0.priority" newName="priority_1018"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.74.0.dbprimary_acc" newName="dbprimary_acc_1074"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.24.0.linkage_type" newName="linkage_type_1024"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="10.6.0.iri"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="10.6.0.iri" newName="iri_1006"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="10.3.0.title"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="10.3.0.title" newName="title_1003"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.18.0.db_display_name"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.18.0.db_display_name" newName="db_display_name_1018"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.18.0.type"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.18.0.type" newName="type_1018"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.74.0.info_type"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.74.0.info_type" newName="info_type_1074"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.24.0.source_xref_id"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.24.0.source_xref_id" newName="source_xref_id_1024"/>
+		<maskedColumn tableKey="transcript__object_xref_1" colKey="1.18.0.description"/>
+		<renamedColumn tableKey="transcript__object_xref_1" colKey="1.18.0.description" newName="description_1018"/>
+		<alternativeJoin tableKey="transcript__object_xref_1" relationId="727"/>
+		<alternativeJoin tableKey="transcript__object_xref_1" relationId="732"/>
+		<alternativeJoin tableKey="transcript__object_xref_1" relationId="3089"/>
+		<alternativeJoin tableKey="transcript__object_xref_1" relationId="755"/>
+		<alternativeJoin tableKey="transcript__object_xref_1" relationId="786"/>
+		<transformStart tableKey="transcript__object_xref_1" tableId="342"/>
+		<restrictedTable tableKey="transcript__object_xref_1" tableId="677" aliasColumnIds="678,682" aliasNames="col2,col1" expression=":col1='Transcript' AND (:col2!='NOT' OR :col2 IS NULL)"/>
+		<alternativeJoin tableKey="transcript__object_xref_1" relationId="3089"/>
+		<alternativeJoin tableKey="transcript__object_xref_1" relationId="2348"/>
+		<renamedTable tableKey="transcript__exon_transcript" newName="exon_transcript"/>
+		<distinctRows tableKey="transcript__exon_transcript"/>
+		<skipOptimiser tableKey="transcript__exon_transcript"/>
+		<maskedColumn tableKey="transcript__exon_transcript" colKey="1.15.0.is_current"/>
+		<renamedColumn tableKey="transcript__exon_transcript" colKey="1.15.0.is_current" newName="is_current_1015"/>
+		<renamedColumn tableKey="transcript__exon_transcript" colKey="1.17.0.rank" newName="rank_1017"/>
+		<renamedColumn tableKey="transcript__exon_transcript" colKey="1.60.0.value" newName="value_1060"/>
+		<renamedColumn tableKey="transcript__exon_transcript" colKey="1.15.0.is_constitutive" newName="is_constitutive_1015"/>
+		<maskedColumn tableKey="transcript__exon_transcript" colKey="1.15.0.created_date"/>
+		<renamedColumn tableKey="transcript__exon_transcript" colKey="1.15.0.created_date" newName="created_date_1016"/>
+		<maskedColumn tableKey="transcript__exon_transcript" colKey="1.15.0.version"/>
+		<renamedColumn tableKey="transcript__exon_transcript" colKey="1.15.0.version" newName="version_1016"/>
+		<maskedColumn tableKey="transcript__exon_transcript" colKey="1.59.0.coord_system_id"/>
+		<renamedColumn tableKey="transcript__exon_transcript" colKey="1.59.0.coord_system_id" newName="coord_system_id_1059"/>
+		<maskedColumn tableKey="transcript__exon_transcript" colKey="1.15.0.seq_region_id"/>
+		<renamedColumn tableKey="transcript__exon_transcript" colKey="1.15.0.seq_region_id" newName="seq_region_id_1015"/>
+		<renamedColumn tableKey="transcript__exon_transcript" colKey="1.15.0.seq_region_end" newName="seq_region_end_1015"/>
+		<maskedColumn tableKey="transcript__exon_transcript" colKey="1.15.0.modified_date"/>
+		<renamedColumn tableKey="transcript__exon_transcript" colKey="1.15.0.modified_date" newName="modified_date_1016"/>
+		<maskedColumn tableKey="transcript__exon_transcript" colKey="1.59.0.length"/>
+		<renamedColumn tableKey="transcript__exon_transcript" colKey="1.59.0.length" newName="length_1059"/>
+		<renamedColumn tableKey="transcript__exon_transcript" colKey="1.17.0.exon_id" newName="exon_id_1017"/>
+		<renamedColumn tableKey="transcript__exon_transcript" colKey="1.15.0.seq_region_start" newName="seq_region_start_1015"/>
+		<maskedColumn tableKey="transcript__exon_transcript" colKey="1.15.0.seq_region_strand"/>
+		<renamedColumn tableKey="transcript__exon_transcript" colKey="1.15.0.seq_region_strand" newName="seq_region_strand_1015"/>
+		<maskedColumn tableKey="transcript__exon_transcript" colKey="1.60.0.attrib_type_id"/>
+		<renamedColumn tableKey="transcript__exon_transcript" colKey="1.60.0.attrib_type_id" newName="attrib_type_id_1060"/>
+		<renamedColumn tableKey="transcript__exon_transcript" colKey="1.15.0.phase" newName="phase_1015"/>
+		<indexedColumn tableKey="transcript__exon_transcript" colKey="1.15.0.stable_id"/>
+		<renamedColumn tableKey="transcript__exon_transcript" colKey="1.15.0.stable_id" newName="stable_id_1016"/>
+		<renamedColumn tableKey="transcript__exon_transcript" colKey="1.15.0.end_phase" newName="end_phase_1015"/>
+		<maskedColumn tableKey="transcript__exon_transcript" colKey="1.59.0.name"/>
+		<renamedColumn tableKey="transcript__exon_transcript" colKey="1.59.0.name" newName="name_1059"/>
+		<alternativeJoin tableKey="transcript__exon_transcript" relationId="714"/>
+		<alternativeJoin tableKey="transcript__exon_transcript" relationId="759"/>
+		<maskedRelation tableKey="transcript__exon_transcript" relationId="759"/>
+		<maskedRelation tableKey="transcript__exon_transcript" relationId="768"/>
+		<maskedRelation tableKey="transcript__exon_transcript" relationId="791"/>
+		<restrictedTable tableKey="transcript__exon_transcript" tableId="22" aliasColumnIds="24" aliasNames="col1" expression=":col1=11 or :col1 is null"/>
+		<maskedTable tableKey="transcript__transcript_supporting_feature"/>
+		<renamedTable tableKey="transcript__transcript_supporting_feature" newName="transcript_supporting_feature"/>
+		<renamedColumn tableKey="transcript__transcript_supporting_feature" colKey="1.67.0.feature_type" newName="feature_type_1067"/>
+		<renamedColumn tableKey="transcript__transcript_supporting_feature" colKey="1.67.0.feature_id" newName="feature_id_1067"/>
+		<maskedTable tableKey="gene__alt_allele"/>
+		<renamedTable tableKey="gene__alt_allele" newName="alt_allele"/>
+		<renamedColumn tableKey="gene__alt_allele" colKey="1.1.0.alt_allele_group_id" newName="alt_allele_group_id_101"/>
+		<renamedColumn tableKey="gene__alt_allele" colKey="1.1.0.alt_allele_id" newName="alt_allele_id_101"/>
+		<renamedTable tableKey="transcript__transcript_attrib" newName="tra"/>
+		<skipOptimiser tableKey="transcript__transcript_attrib"/>
+		<maskedColumn tableKey="transcript__transcript_attrib" colKey="1.6.0.name"/>
+		<renamedColumn tableKey="transcript__transcript_attrib" colKey="1.6.0.name" newName="name_106"/>
+		<maskedColumn tableKey="transcript__transcript_attrib" colKey="1.6.0.description"/>
+		<renamedColumn tableKey="transcript__transcript_attrib" colKey="1.6.0.description" newName="description_106"/>
+		<maskedColumn tableKey="transcript__transcript_attrib" colKey="1.65.0.attrib_type_id"/>
+		<renamedColumn tableKey="transcript__transcript_attrib" colKey="1.65.0.attrib_type_id" newName="attrib_type_id_1065"/>
+		<maskedColumn tableKey="transcript__transcript_attrib" colKey="1.6.0.code"/>
+		<renamedColumn tableKey="transcript__transcript_attrib" colKey="1.6.0.code" newName="code_106"/>
+		<renamedColumn tableKey="transcript__transcript_attrib" colKey="1.65.0.value" newName="value_1065"/>
+		<maskedRelation tableKey="transcript__transcript_attrib" relationId="736"/>
+		<maskedRelation tableKey="transcript__transcript_attrib" relationId="741"/>
+		<maskedRelation tableKey="transcript__transcript_attrib" relationId="759"/>
+		<maskedRelation tableKey="transcript__transcript_attrib" relationId="763"/>
+		<maskedRelation tableKey="transcript__transcript_attrib" relationId="764"/>
+		<maskedTable tableKey="gene__operon_transcript_gene"/>
+		<renamedTable tableKey="gene__operon_transcript_gene" newName="operon_transcript_gene"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.7.0.species_id" newName="species_id_107"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.7.0.name" newName="name_107"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.6.0.name" newName="name_106"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.60.1.value" newName="value_1060_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.83.0.seq_region_strand" newName="seq_region_strand_1083"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.1.created" newName="created_102_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.7.1.rank" newName="rank_107_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.85.0.seq_region_start" newName="seq_region_start_1085"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.83.0.created_date" newName="created_date_1083"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.83.0.analysis_id" newName="analysis_id_1083"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.59.0.length" newName="length_1059"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.59.1.length" newName="length_1059_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.85.0.stable_id" newName="stable_id_1085"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.1.program_version" newName="program_version_102_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.0.module_version" newName="module_version_102"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.6.0.code" newName="code_106"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.7.1.attrib" newName="attrib_107_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.1.logic_name" newName="logic_name_102_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.0.module" newName="module_102"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.1.db" newName="db_102_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.83.0.stable_id" newName="stable_id_1083"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.7.0.attrib" newName="attrib_107"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.7.0.rank" newName="rank_107"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.85.0.seq_region_end" newName="seq_region_end_1085"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.85.0.version" newName="version_1085"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.0.program_version" newName="program_version_102"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.85.0.created_date" newName="created_date_1085"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.0.db_version" newName="db_version_102"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.0.gff_source" newName="gff_source_102"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.7.1.name" newName="name_107_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.83.0.seq_region_id" newName="seq_region_id_1083"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.1.program" newName="program_102_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.1.db_version" newName="db_version_102_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.85.0.modified_date" newName="modified_date_1085"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.83.0.seq_region_end" newName="seq_region_end_1083"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.59.1.coord_system_id" newName="coord_system_id_1059_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.7.1.version" newName="version_107_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.1.gff_source" newName="gff_source_102_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.85.0.operon_id" newName="operon_id_1085"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.85.0.analysis_id" newName="analysis_id_1085"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.1.gff_feature" newName="gff_feature_102_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.83.0.modified_date" newName="modified_date_1083"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.1.parameters" newName="parameters_102_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.0.created" newName="created_102"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.6.0.description" newName="description_106"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.0.logic_name" newName="logic_name_102"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.59.1.name" newName="name_1059_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.0.gff_feature" newName="gff_feature_102"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.6.1.code" newName="code_106_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.60.1.attrib_type_id" newName="attrib_type_id_1060_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.83.0.display_label" newName="display_label_1083"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.85.0.seq_region_strand" newName="seq_region_strand_1085"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.83.0.version" newName="version_1083"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.0.db_file" newName="db_file_102"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.6.1.description" newName="description_106_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.59.0.name" newName="name_1059"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.85.0.seq_region_id" newName="seq_region_id_1085"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.85.0.display_label" newName="display_label_1085"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.1.module" newName="module_102_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.60.0.value" newName="value_1060"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.1.db_file" newName="db_file_102_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.1.module_version" newName="module_version_102_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.86.0.operon_transcript_id" newName="operon_transcript_id_1086"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.59.0.coord_system_id" newName="coord_system_id_1059"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.6.1.name" newName="name_106_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.7.1.species_id" newName="species_id_107_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.0.parameters" newName="parameters_102"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.7.0.version" newName="version_107"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.83.0.seq_region_start" newName="seq_region_start_1083"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.1.program_file" newName="program_file_102_r1"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.0.program_file" newName="program_file_102"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.0.program" newName="program_102"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.60.0.attrib_type_id" newName="attrib_type_id_1060"/>
+		<renamedColumn tableKey="gene__operon_transcript_gene" colKey="1.2.0.db" newName="db_102"/>
+		<renamedTable tableKey="gene__transcript" newName="transcript"/>
+		<distinctRows tableKey="gene__transcript"/>
+		<maskedColumn tableKey="gene__transcript" colKey="description_1074"/>
+		<maskedColumn tableKey="gene__transcript" colKey="version_1074"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.64.0.seq_region_start" newName="seq_region_start_1064"/>
+		<maskedColumn tableKey="gene__transcript" colKey="1.64.0.modified_date"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.64.0.modified_date" newName="modified_date_1064"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.74.0.display_label" newName="display_label_1074_r1"/>
+		<maskedColumn tableKey="gene__transcript" colKey="secondary_db_table_1018"/>
+		<maskedColumn tableKey="gene__transcript" colKey="modified_date_1020"/>
+		<indexedColumn tableKey="gene__transcript" colKey="stable_id_1023"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.64.0.source" newName="source_1064"/>
+		<indexedColumn tableKey="gene__transcript" colKey="1.64.0.stable_id"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.64.0.stable_id" newName="stable_id_1066"/>
+		<maskedColumn tableKey="gene__transcript" colKey="display_xref_id_1020"/>
+		<maskedColumn tableKey="gene__transcript" colKey="stain_1027"/>
+		<maskedColumn tableKey="gene__transcript" colKey="seq_region_id_1020"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.64.0.transcript_id" newName="transcript_id_1064_key"/>
+		<maskedColumn tableKey="gene__transcript" colKey="info_type_1074"/>
+		<maskedColumn tableKey="gene__transcript" colKey="1.18.0.status"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.18.0.status" newName="status_1018_r1"/>
+		<maskedColumn tableKey="gene__transcript" colKey="1.18.0.db_name"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.18.0.db_name" newName="db_name_1018_r1"/>
+		<maskedColumn tableKey="gene__transcript" colKey="created_date_1020"/>
+		<maskedColumn tableKey="gene__transcript" colKey="db_name_1018"/>
+		<maskedColumn tableKey="gene__transcript" colKey="db_release_1018"/>
+		<maskedColumn tableKey="gene__transcript" colKey="1.74.0.info_text"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.74.0.info_text" newName="info_text_1074_r1"/>
+		<maskedColumn tableKey="gene__transcript" colKey="length_1059"/>
+		<maskedColumn tableKey="gene__transcript" colKey="1.18.0.secondary_db_table"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.18.0.secondary_db_table" newName="secondary_db_table_1018_r1"/>
+		<maskedColumn tableKey="gene__transcript" colKey="is_current_1020"/>
+		<maskedColumn tableKey="gene__transcript" colKey="1.64.0.display_xref_id"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.64.0.display_xref_id" newName="display_xref_id_1064"/>
+		<maskedColumn tableKey="gene__transcript" colKey="1.74.0.dbprimary_acc"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.74.0.dbprimary_acc" newName="dbprimary_acc_1074_r1"/>
+		<maskedColumn tableKey="gene__transcript" colKey="1.18.0.priority"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.18.0.priority" newName="priority_1018_r1"/>
+		<maskedColumn tableKey="gene__transcript" colKey="1.18.0.type"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.18.0.type" newName="type_1018_r1"/>
+		<maskedColumn tableKey="gene__transcript" colKey="1.74.0.info_type"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.74.0.info_type" newName="info_type_1074_r1"/>
+		<maskedColumn tableKey="gene__transcript" colKey="1.18.0.description"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.18.0.description" newName="description_1018_r1"/>
+		<maskedColumn tableKey="gene__transcript" colKey="type_1018"/>
+		<maskedColumn tableKey="gene__transcript" colKey="analysis_id_1020"/>
+		<maskedColumn tableKey="gene__transcript" colKey="info_text_1074"/>
+		<maskedColumn tableKey="gene__transcript" colKey="1.64.0.analysis_id"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.64.0.analysis_id" newName="analysis_id_1064"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.64.0.seq_region_strand" newName="seq_region_strand_1064"/>
+		<maskedColumn tableKey="gene__transcript" colKey="seq_region_end_1027"/>
+		<maskedColumn tableKey="gene__transcript" colKey="priority_1018"/>
+		<maskedColumn tableKey="gene__transcript" colKey="canonical_transcript_id_1020"/>
+		<maskedColumn tableKey="gene__transcript" colKey="1.64.0.is_current"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.64.0.is_current" newName="is_current_1064"/>
+		<maskedColumn tableKey="gene__transcript" colKey="1.18.0.db_release"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.18.0.db_release" newName="db_release_1018_r1"/>
+		<maskedColumn tableKey="gene__transcript" colKey="seq_region_start_1027"/>
+		<maskedColumn tableKey="gene__transcript" colKey="1.18.0.secondary_db_name"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.18.0.secondary_db_name" newName="secondary_db_name_1018_r1"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.64.0.seq_region_end" newName="seq_region_end_1064"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.64.0.version" newName="version_1064"/>
+		<maskedColumn tableKey="gene__transcript" colKey="attrib_type_id_1022"/>
+		<indexedColumn tableKey="gene__transcript" colKey="name_1059"/>
+		<maskedColumn tableKey="gene__transcript" colKey="secondary_db_name_1018"/>
+		<indexedColumn tableKey="gene__transcript" colKey="seq_region_start_1020"/>
+		<maskedColumn tableKey="gene__transcript" colKey="1.74.0.external_db_id"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.74.0.external_db_id" newName="external_db_id_1074_r1"/>
+		<maskedColumn tableKey="gene__transcript" colKey="1.64.0.canonical_translation_id"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.64.0.canonical_translation_id" newName="canonical_translation_id_1064"/>
+		<maskedColumn tableKey="gene__transcript" colKey="1.64.0.created_date"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.64.0.created_date" newName="created_date_1064"/>
+		<maskedColumn tableKey="gene__transcript" colKey="1.74.0.version"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.74.0.version" newName="version_1074_r1"/>
+		<maskedColumn tableKey="gene__transcript" colKey="1.74.0.description"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.74.0.description" newName="description_1074_r1"/>
+		<maskedColumn tableKey="gene__transcript" colKey="status_1018"/>
+		<maskedColumn tableKey="gene__transcript" colKey="description_1018"/>
+		<maskedColumn tableKey="gene__transcript" colKey="coord_system_id_1059"/>
+		<maskedColumn tableKey="gene__transcript" colKey="1.64.0.seq_region_id"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.64.0.seq_region_id" newName="seq_region_id_1064"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.64.0.biotype" newName="biotype_1064"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.18.0.db_display_name" newName="db_display_name_1018_r1"/>
+		<maskedColumn tableKey="gene__transcript" colKey="external_db_id_1074"/>
+		<maskedColumn tableKey="gene__transcript" colKey="karyotype_id_1027"/>
+		<maskedColumn tableKey="gene__transcript" colKey="1.64.0.description"/>
+		<renamedColumn tableKey="gene__transcript" colKey="1.64.0.description" newName="description_1064"/>
+		<maskedColumn tableKey="gene__transcript" colKey="dbprimary_acc_1074"/>
+		<maskedRelation tableKey="gene__transcript" relationId="714"/>
+		<maskedRelation tableKey="gene__transcript" relationId="720"/>
+		<maskedRelation tableKey="gene__transcript" relationId="723"/>
+		<maskedRelation tableKey="gene__transcript" relationId="725"/>
+		<maskedRelation tableKey="gene__transcript" relationId="726"/>
+		<maskedRelation tableKey="gene__transcript" relationId="728"/>
+		<maskedRelation tableKey="gene__transcript" relationId="730"/>
+		<maskedRelation tableKey="gene__transcript" relationId="732"/>
+		<maskedRelation tableKey="gene__transcript" relationId="3089"/>
+		<maskedRelation tableKey="gene__transcript" relationId="734"/>
+		<maskedRelation tableKey="gene__transcript" relationId="749"/>
+		<maskedRelation tableKey="gene__transcript" relationId="750"/>
+		<maskedRelation tableKey="gene__transcript" relationId="757"/>
+		<maskedRelation tableKey="gene__transcript" relationId="759"/>
+		<maskedRelation tableKey="gene__transcript" relationId="761"/>
+		<maskedRelation tableKey="gene__transcript" relationId="762"/>
+		<maskedRelation tableKey="gene__transcript" relationId="768"/>
+		<maskedRelation tableKey="gene__transcript" relationId="774"/>
+		<maskedRelation tableKey="gene__transcript" relationId="776"/>
+		<maskedRelation tableKey="gene__transcript" relationId="781"/>
+		<maskedRelation tableKey="gene__transcript" relationId="782"/>
+		<maskedRelation tableKey="gene__transcript" relationId="783"/>
+		<maskedRelation tableKey="gene__transcript" relationId="784"/>
+		<maskedRelation tableKey="gene__transcript" relationId="789"/>
+		<maskedRelation tableKey="gene__transcript" relationId="791"/>
+		<maskedRelation tableKey="gene__transcript" relationId="792"/>
+		<maskedRelation tableKey="gene__transcript" relationId="795"/>
+		<maskedRelation tableKey="gene__transcript" relationId="798"/>
+		<maskedRelation tableKey="gene__transcript" relationId="800"/>
+		<maskedRelation tableKey="gene__transcript" relationId="807"/>
+		<maskedRelation tableKey="gene__transcript" relationId="809"/>
+		<maskedRelation tableKey="gene__transcript" relationId="810"/>
+		<maskedRelation tableKey="gene__transcript" relationId="812"/>
+		<maskedRelation tableKey="gene__transcript" relationId="816"/>
+		<maskedRelation tableKey="gene__transcript" relationId="817"/>
+		<maskedRelation tableKey="gene__transcript" relationId="3089"/>
+		<maskedRelation tableKey="gene__transcript" relationId="2348"/>
+		<renamedTable tableKey="transcript__object_xref" newName="ox"/>
+		<tableHideMasked tableKey="transcript__object_xref"/>
+		<distinctRows tableKey="transcript__object_xref"/>
+		<maskedColumn tableKey="transcript__object_xref" colKey="1.40.0.linkage_annotation"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.40.0.linkage_annotation" newName="linkage_annotation_1040"/>
+		<maskedColumn tableKey="transcript__object_xref" colKey="1.74.0.xref_id"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.74.0.xref_id" newName="xref_id_1074"/>
+		<indexedColumn tableKey="transcript__object_xref" colKey="1.74.0.display_label"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.74.0.display_label" newName="display_label_1074"/>
+		<maskedColumn tableKey="transcript__object_xref" colKey="1.74.0.info_text"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.74.0.info_text" newName="info_text_1074"/>
+		<maskedColumn tableKey="transcript__object_xref" colKey="1.74.0.version"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.74.0.version" newName="version_1074"/>
+		<maskedColumn tableKey="transcript__object_xref" colKey="1.18.0.db_release"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.18.0.db_release" newName="db_release_1018"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.74.0.description" newName="description_1074"/>
+		<maskedColumn tableKey="transcript__object_xref" colKey="1.18.0.secondary_db_table"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.18.0.secondary_db_table" newName="secondary_db_table_1018"/>
+		<maskedColumn tableKey="transcript__object_xref" colKey="1.40.0.ensembl_object_type"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
+		<maskedColumn tableKey="transcript__object_xref" colKey="1.40.0.object_xref_id"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040"/>
+		<maskedColumn tableKey="transcript__object_xref" colKey="1.40.0.analysis_id"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.40.0.analysis_id" newName="analysis_id_1040"/>
+		<maskedColumn tableKey="transcript__object_xref" colKey="1.18.0.secondary_db_name"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.18.0.secondary_db_name" newName="secondary_db_name_1018"/>
+		<maskedColumn tableKey="transcript__object_xref" colKey="1.18.0.priority"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.18.0.priority" newName="priority_1018"/>
+		<indexedColumn tableKey="transcript__object_xref" colKey="1.74.0.dbprimary_acc"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.74.0.dbprimary_acc" newName="dbprimary_acc_1074"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.40.0.ensembl_id" newName="transcript_id_1064_key"/>
+		<maskedColumn tableKey="transcript__object_xref" colKey="1.18.0.db_display_name"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.18.0.db_display_name" newName="db_display_name_1018"/>
+		<maskedColumn tableKey="transcript__object_xref" colKey="1.18.0.type"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.18.0.type" newName="type_1018"/>
+		<maskedColumn tableKey="transcript__object_xref" colKey="1.74.0.info_type"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.74.0.info_type" newName="info_type_1074"/>
+		<maskedColumn tableKey="transcript__object_xref" colKey="1.18.0.external_db_id"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.18.0.external_db_id" newName="external_db_id_1018"/>
+		<maskedColumn tableKey="transcript__object_xref" colKey="1.18.0.description"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.18.0.description" newName="description_1018"/>
+		<maskedColumn tableKey="transcript__object_xref" colKey="1.18.0.status"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.18.0.status" newName="status_1018"/>
+		<maskedColumn tableKey="transcript__object_xref" colKey="1.18.0.db_name"/>
+		<renamedColumn tableKey="transcript__object_xref" colKey="1.18.0.db_name" newName="db_name_1018"/>
+		<alternativeJoin tableKey="transcript__object_xref" relationId="732"/>
+		<maskedRelation tableKey="transcript__object_xref" relationId="732"/>
+		<maskedRelation tableKey="transcript__object_xref" relationId="3089"/>
+		<maskedRelation tableKey="transcript__object_xref" relationId="786"/>
+		<transformStart tableKey="transcript__object_xref" tableId="342"/>
+		<restrictedTable tableKey="transcript__object_xref" tableId="677" aliasColumnIds="682" aliasNames="col1" expression=":col1=&quot;Transcript&quot;"/>
+		<maskedRelation tableKey="transcript__object_xref" relationId="3089"/>
+		<maskedRelation tableKey="transcript__object_xref" relationId="2348"/>
+		<renamedTable tableKey="gene__object_xref" newName="ox"/>
+		<tableHideMasked tableKey="gene__object_xref"/>
+		<distinctRows tableKey="gene__object_xref"/>
+		<maskedColumn tableKey="gene__object_xref" colKey="1.40.0.linkage_annotation"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.40.0.linkage_annotation" newName="linkage_annotation_1040"/>
+		<maskedColumn tableKey="gene__object_xref" colKey="1.74.0.xref_id"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.74.0.xref_id" newName="xref_id_1074"/>
+		<indexedColumn tableKey="gene__object_xref" colKey="1.74.0.display_label"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.74.0.display_label" newName="display_label_1074"/>
+		<maskedColumn tableKey="gene__object_xref" colKey="1.74.0.info_text"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.74.0.info_text" newName="info_text_1074"/>
+		<maskedColumn tableKey="gene__object_xref" colKey="1.74.0.version"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.74.0.version" newName="version_1074"/>
+		<maskedColumn tableKey="gene__object_xref" colKey="1.18.0.db_release"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.18.0.db_release" newName="db_release_1018"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.74.0.description" newName="description_1074"/>
+		<maskedColumn tableKey="gene__object_xref" colKey="1.18.0.secondary_db_table"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.18.0.secondary_db_table" newName="secondary_db_table_1018"/>
+		<maskedColumn tableKey="gene__object_xref" colKey="1.40.0.ensembl_object_type"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
+		<maskedColumn tableKey="gene__object_xref" colKey="1.40.0.object_xref_id"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040"/>
+		<maskedColumn tableKey="gene__object_xref" colKey="1.40.0.analysis_id"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.40.0.analysis_id" newName="analysis_id_1040"/>
+		<maskedColumn tableKey="gene__object_xref" colKey="1.18.0.secondary_db_name"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.18.0.secondary_db_name" newName="secondary_db_name_1018"/>
+		<maskedColumn tableKey="gene__object_xref" colKey="1.18.0.priority"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.18.0.priority" newName="priority_1018"/>
+		<indexedColumn tableKey="gene__object_xref" colKey="1.74.0.dbprimary_acc"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.74.0.dbprimary_acc" newName="dbprimary_acc_1074"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.40.0.ensembl_id" newName="gene_id_1020_key"/>
+		<maskedColumn tableKey="gene__object_xref" colKey="1.18.0.db_display_name"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.18.0.db_display_name" newName="db_display_name_1018"/>
+		<maskedColumn tableKey="gene__object_xref" colKey="1.18.0.type"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.18.0.type" newName="type_1018"/>
+		<maskedColumn tableKey="gene__object_xref" colKey="1.74.0.info_type"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.74.0.info_type" newName="info_type_1074"/>
+		<maskedColumn tableKey="gene__object_xref" colKey="1.18.0.external_db_id"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.18.0.external_db_id" newName="external_db_id_1018"/>
+		<maskedColumn tableKey="gene__object_xref" colKey="1.18.0.description"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.18.0.description" newName="description_1018"/>
+		<maskedColumn tableKey="gene__object_xref" colKey="1.18.0.status"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.18.0.status" newName="status_1018"/>
+		<maskedColumn tableKey="gene__object_xref" colKey="1.18.0.db_name"/>
+		<renamedColumn tableKey="gene__object_xref" colKey="1.18.0.db_name" newName="db_name_1018"/>
+		<alternativeJoin tableKey="gene__object_xref" relationId="732"/>
+		<maskedRelation tableKey="gene__object_xref" relationId="732"/>
+		<maskedRelation tableKey="gene__object_xref" relationId="3089"/>
+		<maskedRelation tableKey="gene__object_xref" relationId="786"/>
+		<transformStart tableKey="gene__object_xref" tableId="342"/>
+		<restrictedTable tableKey="gene__object_xref" tableId="677" aliasColumnIds="682" aliasNames="col1" expression=":col1=&quot;Gene&quot;"/>
+		<maskedRelation tableKey="gene__object_xref" relationId="3089"/>
+		<maskedRelation tableKey="gene__object_xref" relationId="2348"/>
+		<renamedTable tableKey="transcript__translation" newName="translation"/>
+		<distinctRows tableKey="transcript__translation"/>
+		<skipOptimiser tableKey="transcript__translation"/>
+		<maskedColumn tableKey="transcript__translation" colKey="description_1074"/>
+		<maskedColumn tableKey="transcript__translation" colKey="external_db_id_1074_r1"/>
+		<maskedColumn tableKey="transcript__translation" colKey="version_1074"/>
+		<renamedColumn tableKey="transcript__translation" colKey="1.68.0.seq_end" newName="seq_end_1068"/>
+		<maskedColumn tableKey="transcript__translation" colKey="modified_date_1064"/>
+		<maskedColumn tableKey="transcript__translation" colKey="secondary_db_table_1018"/>
+		<maskedColumn tableKey="transcript__translation" colKey="modified_date_1020"/>
+		<indexedColumn tableKey="transcript__translation" colKey="stable_id_1023"/>
+		<maskedColumn tableKey="transcript__translation" colKey="1.69.0.attrib_type_id"/>
+		<renamedColumn tableKey="transcript__translation" colKey="1.69.0.attrib_type_id" newName="attrib_type_id_1069"/>
+		<maskedColumn tableKey="transcript__translation" colKey="priority_1018_r1"/>
+		<maskedColumn tableKey="transcript__translation" colKey="db_name_1018_r1"/>
+		<maskedColumn tableKey="transcript__translation" colKey="canonical_translation_id_1064"/>
+		<maskedColumn tableKey="transcript__translation" colKey="description_1074_r1"/>
+		<maskedColumn tableKey="transcript__translation" colKey="display_xref_id_1020"/>
+		<maskedColumn tableKey="transcript__translation" colKey="stain_1027"/>
+		<maskedColumn tableKey="transcript__translation" colKey="display_xref_id_1064"/>
+		<maskedColumn tableKey="transcript__translation" colKey="seq_region_id_1020"/>
+		<maskedColumn tableKey="transcript__translation" colKey="seq_region_id_1064"/>
+		<maskedColumn tableKey="transcript__translation" colKey="description_1064"/>
+		<maskedColumn tableKey="transcript__translation" colKey="info_type_1074"/>
+		<maskedColumn tableKey="transcript__translation" colKey="status_1018_r1"/>
+		<maskedColumn tableKey="transcript__translation" colKey="created_date_1020"/>
+		<maskedColumn tableKey="transcript__translation" colKey="created_date_1064"/>
+		<maskedColumn tableKey="transcript__translation" colKey="info_text_1074_r1"/>
+		<maskedColumn tableKey="transcript__translation" colKey="description_1018_r1"/>
+		<maskedColumn tableKey="transcript__translation" colKey="db_name_1018"/>
+		<maskedColumn tableKey="transcript__translation" colKey="db_release_1018"/>
+		<maskedColumn tableKey="transcript__translation" colKey="length_1059"/>
+		<maskedColumn tableKey="transcript__translation" colKey="1.68.0.created_date"/>
+		<renamedColumn tableKey="transcript__translation" colKey="1.68.0.created_date" newName="created_date_1068"/>
+		<maskedColumn tableKey="transcript__translation" colKey="is_current_1020"/>
+		<maskedColumn tableKey="transcript__translation" colKey="is_current_1064"/>
+		<indexedColumn tableKey="transcript__translation" colKey="1.68.0.stable_id"/>
+		<renamedColumn tableKey="transcript__translation" colKey="1.68.0.stable_id" newName="stable_id_1070"/>
+		<renamedColumn tableKey="transcript__translation" colKey="1.68.0.translation_id" newName="translation_id_1068_key"/>
+		<maskedColumn tableKey="transcript__translation" colKey="info_type_1074_r1"/>
+		<maskedColumn tableKey="transcript__translation" colKey="type_1018"/>
+		<maskedColumn tableKey="transcript__translation" colKey="analysis_id_1020"/>
+		<maskedColumn tableKey="transcript__translation" colKey="analysis_id_1064"/>
+		<maskedColumn tableKey="transcript__translation" colKey="info_text_1074"/>
+		<maskedColumn tableKey="transcript__translation" colKey="dbprimary_acc_1074_r1"/>
+		<maskedColumn tableKey="transcript__translation" colKey="seq_region_end_1027"/>
+		<renamedColumn tableKey="transcript__translation" colKey="1.69.0.value" newName="value_1069"/>
+		<maskedColumn tableKey="transcript__translation" colKey="priority_1018"/>
+		<maskedColumn tableKey="transcript__translation" colKey="canonical_transcript_id_1020"/>
+		<maskedColumn tableKey="transcript__translation" colKey="secondary_db_name_1018_r1"/>
+		<renamedColumn tableKey="transcript__translation" colKey="1.68.0.seq_start" newName="seq_start_1068"/>
+		<renamedColumn tableKey="transcript__translation" colKey="1.68.0.start_exon_id" newName="start_exon_id_1068"/>
+		<maskedColumn tableKey="transcript__translation" colKey="seq_region_start_1027"/>
+		<maskedColumn tableKey="transcript__translation" colKey="secondary_db_table_1018_r1"/>
+		<maskedColumn tableKey="transcript__translation" colKey="1.68.0.modified_date"/>
+		<renamedColumn tableKey="transcript__translation" colKey="1.68.0.modified_date" newName="modified_date_1068"/>
+		<maskedColumn tableKey="transcript__translation" colKey="attrib_type_id_1022"/>
+		<indexedColumn tableKey="transcript__translation" colKey="name_1059"/>
+		<maskedColumn tableKey="transcript__translation" colKey="type_1018_r1"/>
+		<maskedColumn tableKey="transcript__translation" colKey="secondary_db_name_1018"/>
+		<indexedColumn tableKey="transcript__translation" colKey="seq_region_start_1020"/>
+		<maskedColumn tableKey="transcript__translation" colKey="db_release_1018_r1"/>
+		<maskedColumn tableKey="transcript__translation" colKey="status_1018"/>
+		<maskedColumn tableKey="transcript__translation" colKey="description_1018"/>
+		<indexedColumn tableKey="transcript__translation" colKey="stable_id_1066"/>
+		<maskedColumn tableKey="transcript__translation" colKey="coord_system_id_1059"/>
+		<renamedColumn tableKey="transcript__translation" colKey="1.68.0.version" newName="version_1068"/>
+		<maskedColumn tableKey="transcript__translation" colKey="version_1074_r1"/>
+		<renamedColumn tableKey="transcript__translation" colKey="1.68.0.end_exon_id" newName="end_exon_id_1068"/>
+		<maskedColumn tableKey="transcript__translation" colKey="external_db_id_1074"/>
+		<maskedColumn tableKey="transcript__translation" colKey="karyotype_id_1027"/>
+		<maskedColumn tableKey="transcript__translation" colKey="dbprimary_acc_1074"/>
+		<maskedRelation tableKey="transcript__translation" relationId="741"/>
+		<maskedRelation tableKey="transcript__translation" relationId="759"/>
+		<maskedRelation tableKey="transcript__translation" relationId="763"/>
+		<maskedRelation tableKey="transcript__translation" relationId="764"/>
+		<maskedRelation tableKey="transcript__translation" relationId="785"/>
+		<restrictedTable tableKey="transcript__translation" tableId="473" aliasColumnIds="475" aliasNames="col1" expression=":col1 IN (12,170)"/>
+		<restrictedTable tableKey="transcript__translation" tableId="483" aliasColumnIds="484" aliasNames="col1" expression=":col1 IN ('_selenocysteine', 'initial_met')"/>
+		<renamedTable tableKey="translation__object_xref" newName="ox"/>
+		<tableHideMasked tableKey="translation__object_xref"/>
+		<distinctRows tableKey="translation__object_xref"/>
+		<maskedColumn tableKey="translation__object_xref" colKey="1.40.0.linkage_annotation"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.40.0.linkage_annotation" newName="linkage_annotation_1040"/>
+		<maskedColumn tableKey="translation__object_xref" colKey="1.74.0.xref_id"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.74.0.xref_id" newName="xref_id_1074"/>
+		<indexedColumn tableKey="translation__object_xref" colKey="1.74.0.display_label"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.74.0.display_label" newName="display_label_1074"/>
+		<maskedColumn tableKey="translation__object_xref" colKey="1.74.0.info_text"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.74.0.info_text" newName="info_text_1074"/>
+		<maskedColumn tableKey="translation__object_xref" colKey="1.74.0.version"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.74.0.version" newName="version_1074"/>
+		<maskedColumn tableKey="translation__object_xref" colKey="1.18.0.db_release"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.18.0.db_release" newName="db_release_1018"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.74.0.description" newName="description_1074"/>
+		<maskedColumn tableKey="translation__object_xref" colKey="1.18.0.secondary_db_table"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.18.0.secondary_db_table" newName="secondary_db_table_1018"/>
+		<maskedColumn tableKey="translation__object_xref" colKey="1.40.0.ensembl_object_type"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
+		<maskedColumn tableKey="translation__object_xref" colKey="1.40.0.object_xref_id"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040"/>
+		<maskedColumn tableKey="translation__object_xref" colKey="1.40.0.analysis_id"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.40.0.analysis_id" newName="analysis_id_1040"/>
+		<maskedColumn tableKey="translation__object_xref" colKey="1.18.0.secondary_db_name"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.18.0.secondary_db_name" newName="secondary_db_name_1018"/>
+		<maskedColumn tableKey="translation__object_xref" colKey="1.18.0.priority"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.18.0.priority" newName="priority_1018"/>
+		<indexedColumn tableKey="translation__object_xref" colKey="1.74.0.dbprimary_acc"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.74.0.dbprimary_acc" newName="dbprimary_acc_1074"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.40.0.ensembl_id" newName="translation_id_1068_key"/>
+		<maskedColumn tableKey="translation__object_xref" colKey="1.18.0.db_display_name"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.18.0.db_display_name" newName="db_display_name_1018"/>
+		<maskedColumn tableKey="translation__object_xref" colKey="1.18.0.type"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.18.0.type" newName="type_1018"/>
+		<maskedColumn tableKey="translation__object_xref" colKey="1.74.0.info_type"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.74.0.info_type" newName="info_type_1074"/>
+		<maskedColumn tableKey="translation__object_xref" colKey="1.18.0.external_db_id"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.18.0.external_db_id" newName="external_db_id_1018"/>
+		<maskedColumn tableKey="translation__object_xref" colKey="1.18.0.description"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.18.0.description" newName="description_1018"/>
+		<maskedColumn tableKey="translation__object_xref" colKey="1.18.0.status"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.18.0.status" newName="status_1018"/>
+		<maskedColumn tableKey="translation__object_xref" colKey="1.18.0.db_name"/>
+		<renamedColumn tableKey="translation__object_xref" colKey="1.18.0.db_name" newName="db_name_1018"/>
+		<alternativeJoin tableKey="translation__object_xref" relationId="732"/>
+		<maskedRelation tableKey="translation__object_xref" relationId="732"/>
+		<maskedRelation tableKey="translation__object_xref" relationId="3089"/>
+		<maskedRelation tableKey="translation__object_xref" relationId="786"/>
+		<transformStart tableKey="translation__object_xref" tableId="342"/>
+		<restrictedTable tableKey="translation__object_xref" tableId="677" aliasColumnIds="682" aliasNames="col1" expression=":col1=&quot;Translation&quot;"/>
+		<maskedRelation tableKey="translation__object_xref" relationId="3089"/>
+		<maskedRelation tableKey="translation__object_xref" relationId="2348"/>
+		<renamedTable tableKey="gene__object_xref_1" newName="ontology"/>
+		<tableHideMasked tableKey="gene__object_xref_1"/>
+		<distinctRows tableKey="gene__object_xref_1"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="1.74.0.xref_id"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.74.0.xref_id" newName="xref_id_1074"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="1.74.0.display_label"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.74.0.display_label" newName="display_label_1074"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="1.18.0.db_release"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.18.0.db_release" newName="db_release_1018"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="1.40.0.ensembl_object_type"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="1.40.0.object_xref_id"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="10.6.0.is_root" newName="is_root_1006"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="10.6.0.subsets"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="10.6.0.subsets" newName="subsets_1006"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="10.6.0.is_obsolete"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="10.6.0.is_obsolete" newName="is_obsolete_1006"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="1.18.0.secondary_db_name"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.18.0.secondary_db_name" newName="secondary_db_name_1018"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="10.6.0.term_id"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="10.6.0.term_id" newName="term_id_1006"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.40.0.ensembl_id" newName="gene_id_1020_key"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="1.18.0.external_db_id"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.18.0.external_db_id" newName="external_db_id_1018"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="1.18.0.status"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.18.0.status" newName="status_1018"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="1.18.0.db_name"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.18.0.db_name" newName="db_name_1018"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="10.6.0.ontology_id"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="10.6.0.ontology_id" newName="ontology_id_1006"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="1.40.0.linkage_annotation"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.40.0.linkage_annotation" newName="linkage_annotation_1040"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="10.3.0.name"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="10.3.0.name" newName="name_1003"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="1.74.0.info_text"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.74.0.info_text" newName="info_text_1074"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="1.74.0.version"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.74.0.version" newName="version_1074"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="10.6.0.name" newName="name_1006"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="10.3.0.data_version"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="10.3.0.data_version" newName="data_version_1003"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="1.74.0.description"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.74.0.description" newName="description_1074"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="1.18.0.secondary_db_table"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.18.0.secondary_db_table" newName="secondary_db_table_1018"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="1.40.0.analysis_id"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.40.0.analysis_id" newName="analysis_id_1040"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="10.3.0.namespace" newName="namespace_1003"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="10.6.0.definition" newName="definition_1006"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="1.18.0.priority"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.18.0.priority" newName="priority_1018"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.74.0.dbprimary_acc" newName="dbprimary_acc_1074"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.24.0.linkage_type" newName="linkage_type_1024"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="10.6.0.iri"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="10.6.0.iri" newName="iri_1006"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="10.3.0.title"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="10.3.0.title" newName="title_1003"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="1.18.0.db_display_name"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.18.0.db_display_name" newName="db_display_name_1018"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="1.18.0.type"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.18.0.type" newName="type_1018"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="1.74.0.info_type"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.74.0.info_type" newName="info_type_1074"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="1.24.0.source_xref_id"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.24.0.source_xref_id" newName="source_xref_id_1024"/>
+		<maskedColumn tableKey="gene__object_xref_1" colKey="1.18.0.description"/>
+		<renamedColumn tableKey="gene__object_xref_1" colKey="1.18.0.description" newName="description_1018"/>
+		<alternativeJoin tableKey="gene__object_xref_1" relationId="727"/>
+		<maskedRelation tableKey="gene__object_xref_1" relationId="732"/>
+		<alternativeJoin tableKey="gene__object_xref_1" relationId="3089"/>
+		<alternativeJoin tableKey="gene__object_xref_1" relationId="755"/>
+		<alternativeJoin tableKey="gene__object_xref_1" relationId="786"/>
+		<transformStart tableKey="gene__object_xref_1" tableId="342"/>
+		<restrictedTable tableKey="gene__object_xref_1" tableId="677" aliasColumnIds="678,682" aliasNames="col2,col1" expression=":col1='Gene' AND (:col2!='NOT' OR :col2 IS NULL)"/>
+		<alternativeJoin tableKey="gene__object_xref_1" relationId="3089"/>
+		<alternativeJoin tableKey="gene__object_xref_1" relationId="2348"/>
+	</dataset>
+	<dataset name="MTMP_probestuff_helper" centralTableId="856" optimiser="NONE" invisible="false" masked="false" hideMasked="false" indexOptimiser="false">
+		<renamedTable tableKey="MTMP_probestuff_helper" newName="MTMP_probestuff_helper"/>
+		<renamedColumn tableKey="MTMP_probestuff_helper" colKey="11.56.0.is_probeset_array" newName="is_probeset_array_11056"/>
+		<maskedColumn tableKey="MTMP_probestuff_helper" colKey="11.56.0.transcript_stable_id"/>
+		<renamedColumn tableKey="MTMP_probestuff_helper" colKey="11.56.0.transcript_stable_id" newName="transcript_stable_id_11056"/>
+		<maskedColumn tableKey="MTMP_probestuff_helper" colKey="11.56.0.display_label"/>
+		<renamedColumn tableKey="MTMP_probestuff_helper" colKey="11.56.0.display_label" newName="display_label_11056"/>
+		<maskedColumn tableKey="MTMP_probestuff_helper" colKey="11.56.0.array_name"/>
+		<renamedColumn tableKey="MTMP_probestuff_helper" colKey="11.56.0.array_name" newName="array_name_11056"/>
+		<renamedColumn tableKey="MTMP_probestuff_helper" colKey="11.56.0.array_vendor_and_name" newName="array_vendor_and_name_11056"/>
+		<maskedRelation tableKey="MTMP_probestuff_helper" relationId="3087"/>
+		<maskedRelation tableKey="MTMP_probestuff_helper" relationId="3087"/>
+	</dataset>
+	<dataset name="attrib_type" centralTableId="483" optimiser="NONE" invisible="false" masked="false" hideMasked="false" indexOptimiser="false">
+		<renamedTable tableKey="attrib_type" newName="attrib_type"/>
+		<renamedColumn tableKey="attrib_type" colKey="1.6.0.name" newName="name_106"/>
+		<renamedColumn tableKey="attrib_type" colKey="1.6.0.description" newName="description_106"/>
+		<renamedColumn tableKey="attrib_type" colKey="1.6.0.code" newName="code_106"/>
+		<renamedColumn tableKey="attrib_type" colKey="1.6.0.attrib_type_id" newName="attrib_type_id_106_key"/>
+		<restrictedTable tableKey="attrib_type" tableId="483" aliasColumnIds="484" aliasNames="col1" expression=":col1 IN (&quot;appris&quot;,&quot;TSL&quot;,&quot;gencode_basic&quot;,&quot;MANE_Select&quot;)"/>
+	</dataset>
+	<dataset name="object_xref" centralTableId="677" optimiser="NONE" invisible="false" masked="false" hideMasked="false" indexOptimiser="false">
+		<renamedTable tableKey="object_xref" newName="object_xref"/>
+		<explainHideMasked tableKey="object_xref"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.biotype" newName="biotype_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.version" newName="version_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.seq_region_strand" newName="seq_region_strand_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.display_label" newName="display_label_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.xref_id" newName="xref_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.description" newName="description_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_release" newName="db_release_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.created_date" newName="created_date_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040_key"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.secondary_db_name" newName="secondary_db_name_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.stable_id" newName="stable_id_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.analysis_id" newName="analysis_id_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_id" newName="ensembl_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.status" newName="status_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.external_db_id" newName="external_db_id_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_name" newName="db_name_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.canonical_transcript_id" newName="canonical_transcript_id_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.is_current" newName="is_current_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.linkage_annotation" newName="linkage_annotation_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.seq_region_id" newName="seq_region_id_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.seq_region_end" newName="seq_region_end_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.display_xref_id" newName="display_xref_id_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.info_text" newName="info_text_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.version" newName="version_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.seq_region_start" newName="seq_region_start_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.description" newName="description_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.source" newName="source_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.secondary_db_table" newName="secondary_db_table_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.analysis_id" newName="analysis_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.dbprimary_acc" newName="dbprimary_acc_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.priority" newName="priority_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_display_name" newName="db_display_name_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.type" newName="type_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.info_type" newName="info_type_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.description" newName="description_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.modified_date" newName="modified_date_1020"/>
+		<maskedRelation tableKey="object_xref" relationId="714"/>
+		<maskedRelation tableKey="object_xref" relationId="715"/>
+		<maskedRelation tableKey="object_xref" relationId="720"/>
+		<maskedRelation tableKey="object_xref" relationId="723"/>
+		<maskedRelation tableKey="object_xref" relationId="725"/>
+		<maskedRelation tableKey="object_xref" relationId="726"/>
+		<maskedRelation tableKey="object_xref" relationId="728"/>
+		<maskedRelation tableKey="object_xref" relationId="729"/>
+		<maskedRelation tableKey="object_xref" relationId="730"/>
+		<maskedRelation tableKey="object_xref" relationId="732"/>
+		<maskedRelation tableKey="object_xref" relationId="3089"/>
+		<maskedRelation tableKey="object_xref" relationId="734"/>
+		<maskedRelation tableKey="object_xref" relationId="738"/>
+		<maskedRelation tableKey="object_xref" relationId="741"/>
+		<maskedRelation tableKey="object_xref" relationId="742"/>
+		<maskedRelation tableKey="object_xref" relationId="744"/>
+		<maskedRelation tableKey="object_xref" relationId="746"/>
+		<maskedRelation tableKey="object_xref" relationId="749"/>
+		<maskedRelation tableKey="object_xref" relationId="750"/>
+		<maskedRelation tableKey="object_xref" relationId="752"/>
+		<maskedRelation tableKey="object_xref" relationId="757"/>
+		<maskedRelation tableKey="object_xref" relationId="761"/>
+		<maskedRelation tableKey="object_xref" relationId="762"/>
+		<maskedRelation tableKey="object_xref" relationId="766"/>
+		<maskedRelation tableKey="object_xref" relationId="768"/>
+		<maskedRelation tableKey="object_xref" relationId="771"/>
+		<maskedRelation tableKey="object_xref" relationId="774"/>
+		<maskedRelation tableKey="object_xref" relationId="776"/>
+		<maskedRelation tableKey="object_xref" relationId="778"/>
+		<maskedRelation tableKey="object_xref" relationId="781"/>
+		<maskedRelation tableKey="object_xref" relationId="782"/>
+		<maskedRelation tableKey="object_xref" relationId="783"/>
+		<maskedRelation tableKey="object_xref" relationId="784"/>
+		<maskedRelation tableKey="object_xref" relationId="786"/>
+		<maskedRelation tableKey="object_xref" relationId="789"/>
+		<maskedRelation tableKey="object_xref" relationId="792"/>
+		<maskedRelation tableKey="object_xref" relationId="795"/>
+		<maskedRelation tableKey="object_xref" relationId="798"/>
+		<maskedRelation tableKey="object_xref" relationId="800"/>
+		<maskedRelation tableKey="object_xref" relationId="803"/>
+		<maskedRelation tableKey="object_xref" relationId="807"/>
+		<maskedRelation tableKey="object_xref" relationId="809"/>
+		<maskedRelation tableKey="object_xref" relationId="810"/>
+		<maskedRelation tableKey="object_xref" relationId="812"/>
+		<maskedRelation tableKey="object_xref" relationId="814"/>
+		<maskedRelation tableKey="object_xref" relationId="816"/>
+		<maskedRelation tableKey="object_xref" relationId="817"/>
+		<restrictedTable tableKey="object_xref" tableId="677" aliasColumnIds="682" aliasNames="col1" expression=":col1=&quot;Gene&quot;"/>
+		<maskedRelation tableKey="object_xref" relationId="3089"/>
+		<maskedRelation tableKey="object_xref" relationId="2348"/>
+	</dataset>
+	<dataset name="object_xref_copy" centralTableId="677" optimiser="NONE" invisible="false" masked="false" hideMasked="false" indexOptimiser="false">
+		<renamedTable tableKey="object_xref" newName="object_xref"/>
+		<explainHideMasked tableKey="object_xref"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.analysis_id" newName="analysis_id_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.seq_region_strand" newName="seq_region_strand_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.seq_region_start" newName="seq_region_start_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.modified_date" newName="modified_date_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.display_label" newName="display_label_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.xref_id" newName="xref_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.is_current" newName="is_current_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_release" newName="db_release_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.source" newName="source_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.stable_id" newName="stable_id_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040_key"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.gene_id" newName="gene_id_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.secondary_db_name" newName="secondary_db_name_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.seq_region_end" newName="seq_region_end_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_id" newName="ensembl_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.version" newName="version_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.status" newName="status_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.external_db_id" newName="external_db_id_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_name" newName="db_name_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.canonical_translation_id" newName="canonical_translation_id_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.linkage_annotation" newName="linkage_annotation_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.created_date" newName="created_date_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.info_text" newName="info_text_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.version" newName="version_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.description" newName="description_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.seq_region_id" newName="seq_region_id_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.secondary_db_table" newName="secondary_db_table_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.analysis_id" newName="analysis_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.display_xref_id" newName="display_xref_id_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.dbprimary_acc" newName="dbprimary_acc_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.priority" newName="priority_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.biotype" newName="biotype_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_display_name" newName="db_display_name_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.type" newName="type_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.info_type" newName="info_type_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.description" newName="description_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.description" newName="description_1064"/>
+		<maskedRelation tableKey="object_xref" relationId="714"/>
+		<maskedRelation tableKey="object_xref" relationId="720"/>
+		<maskedRelation tableKey="object_xref" relationId="723"/>
+		<maskedRelation tableKey="object_xref" relationId="725"/>
+		<maskedRelation tableKey="object_xref" relationId="726"/>
+		<maskedRelation tableKey="object_xref" relationId="728"/>
+		<maskedRelation tableKey="object_xref" relationId="729"/>
+		<maskedRelation tableKey="object_xref" relationId="730"/>
+		<maskedRelation tableKey="object_xref" relationId="732"/>
+		<maskedRelation tableKey="object_xref" relationId="3089"/>
+		<maskedRelation tableKey="object_xref" relationId="734"/>
+		<maskedRelation tableKey="object_xref" relationId="738"/>
+		<maskedRelation tableKey="object_xref" relationId="741"/>
+		<maskedRelation tableKey="object_xref" relationId="744"/>
+		<maskedRelation tableKey="object_xref" relationId="746"/>
+		<maskedRelation tableKey="object_xref" relationId="749"/>
+		<maskedRelation tableKey="object_xref" relationId="750"/>
+		<maskedRelation tableKey="object_xref" relationId="751"/>
+		<maskedRelation tableKey="object_xref" relationId="757"/>
+		<maskedRelation tableKey="object_xref" relationId="758"/>
+		<maskedRelation tableKey="object_xref" relationId="761"/>
+		<maskedRelation tableKey="object_xref" relationId="762"/>
+		<maskedRelation tableKey="object_xref" relationId="768"/>
+		<maskedRelation tableKey="object_xref" relationId="769"/>
+		<maskedRelation tableKey="object_xref" relationId="771"/>
+		<maskedRelation tableKey="object_xref" relationId="774"/>
+		<maskedRelation tableKey="object_xref" relationId="775"/>
+		<maskedRelation tableKey="object_xref" relationId="776"/>
+		<maskedRelation tableKey="object_xref" relationId="781"/>
+		<maskedRelation tableKey="object_xref" relationId="782"/>
+		<maskedRelation tableKey="object_xref" relationId="783"/>
+		<maskedRelation tableKey="object_xref" relationId="784"/>
+		<maskedRelation tableKey="object_xref" relationId="786"/>
+		<maskedRelation tableKey="object_xref" relationId="789"/>
+		<maskedRelation tableKey="object_xref" relationId="792"/>
+		<maskedRelation tableKey="object_xref" relationId="795"/>
+		<maskedRelation tableKey="object_xref" relationId="798"/>
+		<maskedRelation tableKey="object_xref" relationId="800"/>
+		<maskedRelation tableKey="object_xref" relationId="803"/>
+		<maskedRelation tableKey="object_xref" relationId="807"/>
+		<maskedRelation tableKey="object_xref" relationId="809"/>
+		<maskedRelation tableKey="object_xref" relationId="810"/>
+		<maskedRelation tableKey="object_xref" relationId="812"/>
+		<maskedRelation tableKey="object_xref" relationId="814"/>
+		<maskedRelation tableKey="object_xref" relationId="816"/>
+		<maskedRelation tableKey="object_xref" relationId="817"/>
+		<restrictedTable tableKey="object_xref" tableId="677" aliasColumnIds="682" aliasNames="col1" expression=":col1=&quot;Transcript&quot;"/>
+		<maskedRelation tableKey="object_xref" relationId="3089"/>
+		<maskedRelation tableKey="object_xref" relationId="2348"/>
+	</dataset>
+	<dataset name="object_xref_copy_1" centralTableId="677" optimiser="NONE" invisible="false" masked="false" hideMasked="false" indexOptimiser="false">
+		<renamedTable tableKey="object_xref" newName="object_xref"/>
+		<explainHideMasked tableKey="object_xref"/>
+		<renamedColumn tableKey="object_xref" colKey="1.68.0.seq_end" newName="seq_end_1068"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.display_label" newName="display_label_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.xref_id" newName="xref_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_release" newName="db_release_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.68.0.seq_start" newName="seq_start_1068"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.68.0.start_exon_id" newName="start_exon_id_1068"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040_key"/>
+		<renamedColumn tableKey="object_xref" colKey="1.68.0.modified_date" newName="modified_date_1068"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.secondary_db_name" newName="secondary_db_name_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_id" newName="ensembl_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.status" newName="status_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.external_db_id" newName="external_db_id_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_name" newName="db_name_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.linkage_annotation" newName="linkage_annotation_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.68.0.transcript_id" newName="transcript_id_1068"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.info_text" newName="info_text_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.version" newName="version_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.description" newName="description_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.68.0.created_date" newName="created_date_1068"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.secondary_db_table" newName="secondary_db_table_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.analysis_id" newName="analysis_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.dbprimary_acc" newName="dbprimary_acc_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.priority" newName="priority_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.68.0.stable_id" newName="stable_id_1068"/>
+		<renamedColumn tableKey="object_xref" colKey="1.68.0.version" newName="version_1068"/>
+		<renamedColumn tableKey="object_xref" colKey="1.68.0.end_exon_id" newName="end_exon_id_1068"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_display_name" newName="db_display_name_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.type" newName="type_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.info_type" newName="info_type_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.description" newName="description_1018"/>
+		<maskedRelation tableKey="object_xref" relationId="714"/>
+		<maskedRelation tableKey="object_xref" relationId="715"/>
+		<maskedRelation tableKey="object_xref" relationId="720"/>
+		<maskedRelation tableKey="object_xref" relationId="723"/>
+		<maskedRelation tableKey="object_xref" relationId="725"/>
+		<maskedRelation tableKey="object_xref" relationId="726"/>
+		<maskedRelation tableKey="object_xref" relationId="728"/>
+		<maskedRelation tableKey="object_xref" relationId="729"/>
+		<maskedRelation tableKey="object_xref" relationId="730"/>
+		<maskedRelation tableKey="object_xref" relationId="732"/>
+		<maskedRelation tableKey="object_xref" relationId="3089"/>
+		<maskedRelation tableKey="object_xref" relationId="734"/>
+		<maskedRelation tableKey="object_xref" relationId="738"/>
+		<maskedRelation tableKey="object_xref" relationId="741"/>
+		<maskedRelation tableKey="object_xref" relationId="742"/>
+		<maskedRelation tableKey="object_xref" relationId="744"/>
+		<maskedRelation tableKey="object_xref" relationId="749"/>
+		<maskedRelation tableKey="object_xref" relationId="750"/>
+		<maskedRelation tableKey="object_xref" relationId="751"/>
+		<maskedRelation tableKey="object_xref" relationId="752"/>
+		<maskedRelation tableKey="object_xref" relationId="757"/>
+		<maskedRelation tableKey="object_xref" relationId="761"/>
+		<maskedRelation tableKey="object_xref" relationId="762"/>
+		<maskedRelation tableKey="object_xref" relationId="763"/>
+		<maskedRelation tableKey="object_xref" relationId="766"/>
+		<maskedRelation tableKey="object_xref" relationId="768"/>
+		<maskedRelation tableKey="object_xref" relationId="769"/>
+		<maskedRelation tableKey="object_xref" relationId="771"/>
+		<maskedRelation tableKey="object_xref" relationId="774"/>
+		<maskedRelation tableKey="object_xref" relationId="775"/>
+		<maskedRelation tableKey="object_xref" relationId="776"/>
+		<maskedRelation tableKey="object_xref" relationId="778"/>
+		<maskedRelation tableKey="object_xref" relationId="781"/>
+		<maskedRelation tableKey="object_xref" relationId="782"/>
+		<maskedRelation tableKey="object_xref" relationId="783"/>
+		<maskedRelation tableKey="object_xref" relationId="784"/>
+		<maskedRelation tableKey="object_xref" relationId="786"/>
+		<maskedRelation tableKey="object_xref" relationId="789"/>
+		<maskedRelation tableKey="object_xref" relationId="792"/>
+		<maskedRelation tableKey="object_xref" relationId="795"/>
+		<maskedRelation tableKey="object_xref" relationId="798"/>
+		<maskedRelation tableKey="object_xref" relationId="800"/>
+		<maskedRelation tableKey="object_xref" relationId="807"/>
+		<maskedRelation tableKey="object_xref" relationId="809"/>
+		<maskedRelation tableKey="object_xref" relationId="810"/>
+		<maskedRelation tableKey="object_xref" relationId="812"/>
+		<maskedRelation tableKey="object_xref" relationId="816"/>
+		<maskedRelation tableKey="object_xref" relationId="817"/>
+		<restrictedTable tableKey="object_xref" tableId="677" aliasColumnIds="682" aliasNames="col1" expression=":col1=&quot;Translation&quot;"/>
+		<maskedRelation tableKey="object_xref" relationId="3089"/>
+		<maskedRelation tableKey="object_xref" relationId="2348"/>
+	</dataset>
+	<dataset name="ontology_xref_gene" centralTableId="677" optimiser="NONE" invisible="false" masked="false" hideMasked="false" indexOptimiser="false">
+		<renamedTable tableKey="object_xref" newName="object_xref"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.version" newName="version_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.display_label" newName="display_label_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.xref_id" newName="xref_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.description" newName="description_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.created_date" newName="created_date_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.subsets" newName="subsets_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.stable_id" newName="stable_id_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.analysis_id" newName="analysis_id_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_id" newName="ensembl_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.status" newName="status_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_name" newName="db_name_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.ontology_id" newName="ontology_id_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.seq_region_end" newName="seq_region_end_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="10.3.0.name" newName="name_1003"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.info_text" newName="info_text_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="10.3.0.data_version" newName="data_version_1003"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.secondary_db_table" newName="secondary_db_table_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.definition" newName="definition_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.dbprimary_acc" newName="dbprimary_acc_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.priority" newName="priority_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.iri" newName="iri_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="10.3.0.title" newName="title_1003"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.type" newName="type_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.info_type" newName="info_type_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.description" newName="description_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.modified_date" newName="modified_date_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.biotype" newName="biotype_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.seq_region_strand" newName="seq_region_strand_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_release" newName="db_release_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040_key"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.is_root" newName="is_root_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.is_obsolete" newName="is_obsolete_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.secondary_db_name" newName="secondary_db_name_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.term_id" newName="term_id_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.external_db_id" newName="external_db_id_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.canonical_transcript_id" newName="canonical_transcript_id_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.is_current" newName="is_current_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.linkage_annotation" newName="linkage_annotation_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.seq_region_id" newName="seq_region_id_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.display_xref_id" newName="display_xref_id_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.version" newName="version_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.name" newName="name_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.seq_region_start" newName="seq_region_start_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.description" newName="description_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.20.0.source" newName="source_1020"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.analysis_id" newName="analysis_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="10.3.0.namespace" newName="namespace_1003"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_display_name" newName="db_display_name_1018"/>
+		<maskedRelation tableKey="object_xref" relationId="714"/>
+		<maskedRelation tableKey="object_xref" relationId="715"/>
+		<maskedRelation tableKey="object_xref" relationId="720"/>
+		<maskedRelation tableKey="object_xref" relationId="723"/>
+		<maskedRelation tableKey="object_xref" relationId="725"/>
+		<maskedRelation tableKey="object_xref" relationId="726"/>
+		<maskedRelation tableKey="object_xref" relationId="728"/>
+		<maskedRelation tableKey="object_xref" relationId="729"/>
+		<maskedRelation tableKey="object_xref" relationId="730"/>
+		<maskedRelation tableKey="object_xref" relationId="732"/>
+		<maskedRelation tableKey="object_xref" relationId="734"/>
+		<maskedRelation tableKey="object_xref" relationId="738"/>
+		<maskedRelation tableKey="object_xref" relationId="741"/>
+		<maskedRelation tableKey="object_xref" relationId="742"/>
+		<maskedRelation tableKey="object_xref" relationId="744"/>
+		<maskedRelation tableKey="object_xref" relationId="746"/>
+		<maskedRelation tableKey="object_xref" relationId="749"/>
+		<maskedRelation tableKey="object_xref" relationId="750"/>
+		<maskedRelation tableKey="object_xref" relationId="752"/>
+		<maskedRelation tableKey="object_xref" relationId="757"/>
+		<maskedRelation tableKey="object_xref" relationId="761"/>
+		<maskedRelation tableKey="object_xref" relationId="762"/>
+		<maskedRelation tableKey="object_xref" relationId="766"/>
+		<maskedRelation tableKey="object_xref" relationId="768"/>
+		<maskedRelation tableKey="object_xref" relationId="771"/>
+		<maskedRelation tableKey="object_xref" relationId="774"/>
+		<maskedRelation tableKey="object_xref" relationId="776"/>
+		<maskedRelation tableKey="object_xref" relationId="778"/>
+		<maskedRelation tableKey="object_xref" relationId="781"/>
+		<maskedRelation tableKey="object_xref" relationId="782"/>
+		<maskedRelation tableKey="object_xref" relationId="783"/>
+		<maskedRelation tableKey="object_xref" relationId="784"/>
+		<maskedRelation tableKey="object_xref" relationId="786"/>
+		<maskedRelation tableKey="object_xref" relationId="789"/>
+		<maskedRelation tableKey="object_xref" relationId="792"/>
+		<maskedRelation tableKey="object_xref" relationId="795"/>
+		<maskedRelation tableKey="object_xref" relationId="798"/>
+		<maskedRelation tableKey="object_xref" relationId="800"/>
+		<maskedRelation tableKey="object_xref" relationId="803"/>
+		<maskedRelation tableKey="object_xref" relationId="807"/>
+		<maskedRelation tableKey="object_xref" relationId="809"/>
+		<maskedRelation tableKey="object_xref" relationId="810"/>
+		<maskedRelation tableKey="object_xref" relationId="812"/>
+		<maskedRelation tableKey="object_xref" relationId="814"/>
+		<maskedRelation tableKey="object_xref" relationId="816"/>
+		<maskedRelation tableKey="object_xref" relationId="817"/>
+		<restrictedTable tableKey="object_xref" tableId="677" aliasColumnIds="682" aliasNames="col1" expression=":col1=&quot;Gene&quot;"/>
+	</dataset>
+	<dataset name="ontology_xref_transcript" centralTableId="677" optimiser="NONE" invisible="false" masked="false" hideMasked="false" indexOptimiser="false">
+		<renamedTable tableKey="object_xref" newName="object_xref"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.seq_region_start" newName="seq_region_start_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.modified_date" newName="modified_date_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.display_label" newName="display_label_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.xref_id" newName="xref_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.source" newName="source_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.stable_id" newName="stable_id_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.gene_id" newName="gene_id_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.subsets" newName="subsets_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_id" newName="ensembl_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.status" newName="status_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_name" newName="db_name_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.ontology_id" newName="ontology_id_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="10.3.0.name" newName="name_1003"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.info_text" newName="info_text_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="10.3.0.data_version" newName="data_version_1003"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.secondary_db_table" newName="secondary_db_table_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.definition" newName="definition_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.display_xref_id" newName="display_xref_id_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.dbprimary_acc" newName="dbprimary_acc_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.priority" newName="priority_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.iri" newName="iri_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="10.3.0.title" newName="title_1003"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.type" newName="type_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.info_type" newName="info_type_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.description" newName="description_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.analysis_id" newName="analysis_id_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.seq_region_strand" newName="seq_region_strand_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.is_current" newName="is_current_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_release" newName="db_release_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040_key"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.is_root" newName="is_root_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.is_obsolete" newName="is_obsolete_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.secondary_db_name" newName="secondary_db_name_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.seq_region_end" newName="seq_region_end_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.term_id" newName="term_id_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.version" newName="version_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.external_db_id" newName="external_db_id_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.canonical_translation_id" newName="canonical_translation_id_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.linkage_annotation" newName="linkage_annotation_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.created_date" newName="created_date_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.version" newName="version_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.name" newName="name_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.description" newName="description_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.seq_region_id" newName="seq_region_id_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.analysis_id" newName="analysis_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="10.3.0.namespace" newName="namespace_1003"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.biotype" newName="biotype_1064"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_display_name" newName="db_display_name_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.64.0.description" newName="description_1064"/>
+		<maskedRelation tableKey="object_xref" relationId="714"/>
+		<maskedRelation tableKey="object_xref" relationId="720"/>
+		<maskedRelation tableKey="object_xref" relationId="723"/>
+		<maskedRelation tableKey="object_xref" relationId="725"/>
+		<maskedRelation tableKey="object_xref" relationId="726"/>
+		<maskedRelation tableKey="object_xref" relationId="728"/>
+		<maskedRelation tableKey="object_xref" relationId="729"/>
+		<maskedRelation tableKey="object_xref" relationId="730"/>
+		<maskedRelation tableKey="object_xref" relationId="732"/>
+		<maskedRelation tableKey="object_xref" relationId="734"/>
+		<maskedRelation tableKey="object_xref" relationId="738"/>
+		<maskedRelation tableKey="object_xref" relationId="741"/>
+		<maskedRelation tableKey="object_xref" relationId="744"/>
+		<maskedRelation tableKey="object_xref" relationId="746"/>
+		<maskedRelation tableKey="object_xref" relationId="749"/>
+		<maskedRelation tableKey="object_xref" relationId="750"/>
+		<maskedRelation tableKey="object_xref" relationId="751"/>
+		<maskedRelation tableKey="object_xref" relationId="757"/>
+		<maskedRelation tableKey="object_xref" relationId="758"/>
+		<maskedRelation tableKey="object_xref" relationId="761"/>
+		<maskedRelation tableKey="object_xref" relationId="762"/>
+		<maskedRelation tableKey="object_xref" relationId="768"/>
+		<maskedRelation tableKey="object_xref" relationId="769"/>
+		<maskedRelation tableKey="object_xref" relationId="771"/>
+		<maskedRelation tableKey="object_xref" relationId="774"/>
+		<maskedRelation tableKey="object_xref" relationId="775"/>
+		<maskedRelation tableKey="object_xref" relationId="776"/>
+		<maskedRelation tableKey="object_xref" relationId="781"/>
+		<maskedRelation tableKey="object_xref" relationId="782"/>
+		<maskedRelation tableKey="object_xref" relationId="783"/>
+		<maskedRelation tableKey="object_xref" relationId="784"/>
+		<maskedRelation tableKey="object_xref" relationId="786"/>
+		<maskedRelation tableKey="object_xref" relationId="789"/>
+		<maskedRelation tableKey="object_xref" relationId="792"/>
+		<maskedRelation tableKey="object_xref" relationId="795"/>
+		<maskedRelation tableKey="object_xref" relationId="798"/>
+		<maskedRelation tableKey="object_xref" relationId="800"/>
+		<maskedRelation tableKey="object_xref" relationId="803"/>
+		<maskedRelation tableKey="object_xref" relationId="807"/>
+		<maskedRelation tableKey="object_xref" relationId="809"/>
+		<maskedRelation tableKey="object_xref" relationId="810"/>
+		<maskedRelation tableKey="object_xref" relationId="812"/>
+		<maskedRelation tableKey="object_xref" relationId="814"/>
+		<maskedRelation tableKey="object_xref" relationId="816"/>
+		<maskedRelation tableKey="object_xref" relationId="817"/>
+		<restrictedTable tableKey="object_xref" tableId="677" aliasColumnIds="682" aliasNames="col1" expression=":col1=&quot;Transcript&quot;"/>
+	</dataset>
+	<dataset name="ontology_xref_translation" centralTableId="677" optimiser="NONE" invisible="false" masked="false" hideMasked="false" indexOptimiser="false">
+		<renamedTable tableKey="object_xref" newName="object_xref"/>
+		<renamedColumn tableKey="object_xref" colKey="1.68.0.seq_end" newName="seq_end_1068"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.display_label" newName="display_label_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.xref_id" newName="xref_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_release" newName="db_release_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.68.0.seq_start" newName="seq_start_1068"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_object_type" newName="ensembl_object_type_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.68.0.start_exon_id" newName="start_exon_id_1068"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.object_xref_id" newName="object_xref_id_1040_key"/>
+		<renamedColumn tableKey="object_xref" colKey="1.68.0.modified_date" newName="modified_date_1068"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.is_root" newName="is_root_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.subsets" newName="subsets_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.is_obsolete" newName="is_obsolete_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.secondary_db_name" newName="secondary_db_name_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.term_id" newName="term_id_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.ensembl_id" newName="ensembl_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.status" newName="status_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.external_db_id" newName="external_db_id_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_name" newName="db_name_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.ontology_id" newName="ontology_id_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.linkage_annotation" newName="linkage_annotation_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="10.3.0.name" newName="name_1003"/>
+		<renamedColumn tableKey="object_xref" colKey="1.68.0.transcript_id" newName="transcript_id_1068"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.info_text" newName="info_text_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.version" newName="version_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.name" newName="name_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="10.3.0.data_version" newName="data_version_1003"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.description" newName="description_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.68.0.created_date" newName="created_date_1068"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.secondary_db_table" newName="secondary_db_table_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.40.0.analysis_id" newName="analysis_id_1040"/>
+		<renamedColumn tableKey="object_xref" colKey="10.3.0.namespace" newName="namespace_1003"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.definition" newName="definition_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.dbprimary_acc" newName="dbprimary_acc_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.priority" newName="priority_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="10.6.0.iri" newName="iri_1006"/>
+		<renamedColumn tableKey="object_xref" colKey="1.68.0.stable_id" newName="stable_id_1068"/>
+		<renamedColumn tableKey="object_xref" colKey="1.68.0.version" newName="version_1068"/>
+		<renamedColumn tableKey="object_xref" colKey="10.3.0.title" newName="title_1003"/>
+		<renamedColumn tableKey="object_xref" colKey="1.68.0.end_exon_id" newName="end_exon_id_1068"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.db_display_name" newName="db_display_name_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.type" newName="type_1018"/>
+		<renamedColumn tableKey="object_xref" colKey="1.74.0.info_type" newName="info_type_1074"/>
+		<renamedColumn tableKey="object_xref" colKey="1.18.0.description" newName="description_1018"/>
+		<maskedRelation tableKey="object_xref" relationId="714"/>
+		<maskedRelation tableKey="object_xref" relationId="715"/>
+		<maskedRelation tableKey="object_xref" relationId="720"/>
+		<maskedRelation tableKey="object_xref" relationId="723"/>
+		<maskedRelation tableKey="object_xref" relationId="725"/>
+		<maskedRelation tableKey="object_xref" relationId="726"/>
+		<maskedRelation tableKey="object_xref" relationId="728"/>
+		<maskedRelation tableKey="object_xref" relationId="729"/>
+		<maskedRelation tableKey="object_xref" relationId="730"/>
+		<maskedRelation tableKey="object_xref" relationId="732"/>
+		<maskedRelation tableKey="object_xref" relationId="734"/>
+		<maskedRelation tableKey="object_xref" relationId="738"/>
+		<maskedRelation tableKey="object_xref" relationId="741"/>
+		<maskedRelation tableKey="object_xref" relationId="742"/>
+		<maskedRelation tableKey="object_xref" relationId="744"/>
+		<maskedRelation tableKey="object_xref" relationId="749"/>
+		<maskedRelation tableKey="object_xref" relationId="750"/>
+		<maskedRelation tableKey="object_xref" relationId="751"/>
+		<maskedRelation tableKey="object_xref" relationId="752"/>
+		<maskedRelation tableKey="object_xref" relationId="757"/>
+		<maskedRelation tableKey="object_xref" relationId="761"/>
+		<maskedRelation tableKey="object_xref" relationId="762"/>
+		<maskedRelation tableKey="object_xref" relationId="763"/>
+		<maskedRelation tableKey="object_xref" relationId="766"/>
+		<maskedRelation tableKey="object_xref" relationId="768"/>
+		<maskedRelation tableKey="object_xref" relationId="769"/>
+		<maskedRelation tableKey="object_xref" relationId="771"/>
+		<maskedRelation tableKey="object_xref" relationId="774"/>
+		<maskedRelation tableKey="object_xref" relationId="775"/>
+		<maskedRelation tableKey="object_xref" relationId="776"/>
+		<maskedRelation tableKey="object_xref" relationId="778"/>
+		<maskedRelation tableKey="object_xref" relationId="781"/>
+		<maskedRelation tableKey="object_xref" relationId="782"/>
+		<maskedRelation tableKey="object_xref" relationId="783"/>
+		<maskedRelation tableKey="object_xref" relationId="784"/>
+		<maskedRelation tableKey="object_xref" relationId="786"/>
+		<maskedRelation tableKey="object_xref" relationId="789"/>
+		<maskedRelation tableKey="object_xref" relationId="792"/>
+		<maskedRelation tableKey="object_xref" relationId="795"/>
+		<maskedRelation tableKey="object_xref" relationId="798"/>
+		<maskedRelation tableKey="object_xref" relationId="800"/>
+		<maskedRelation tableKey="object_xref" relationId="807"/>
+		<maskedRelation tableKey="object_xref" relationId="809"/>
+		<maskedRelation tableKey="object_xref" relationId="810"/>
+		<maskedRelation tableKey="object_xref" relationId="812"/>
+		<maskedRelation tableKey="object_xref" relationId="816"/>
+		<maskedRelation tableKey="object_xref" relationId="817"/>
+		<restrictedTable tableKey="object_xref" tableId="677" aliasColumnIds="682" aliasNames="col1" expression=":col1=&quot;Translation&quot;"/>
+	</dataset>
+	<dataset name="protein_feature" centralTableId="354" optimiser="NONE" invisible="false" masked="false" hideMasked="false" indexOptimiser="false">
+		<renamedTable tableKey="protein_feature" newName="protein_feature"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.48.0.perc_ident" newName="perc_ident_1048"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.48.0.external_data" newName="external_data_1048"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.2.0.created" newName="created_102"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.48.0.cigar_line" newName="cigar_line_1048"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.48.0.align_type" newName="align_type_1048"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.48.0.analysis_id" newName="analysis_id_1048"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.2.0.logic_name" newName="logic_name_102"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.48.0.translation_id" newName="translation_id_1048"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.48.0.protein_feature_id" newName="protein_feature_id_1048_key"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.2.0.gff_feature" newName="gff_feature_102"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.2.0.module_version" newName="module_version_102"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.48.0.score" newName="score_1048"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.2.0.db_file" newName="db_file_102"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.48.0.hit_start" newName="hit_start_1048"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.2.0.module" newName="module_102"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.48.0.seq_start" newName="seq_start_1048"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.48.0.hit_description" newName="hit_description_1048"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.2.0.program_version" newName="program_version_102"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.48.0.hit_name" newName="hit_name_1048"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.2.0.db_version" newName="db_version_102"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.2.0.gff_source" newName="gff_source_102"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.2.0.parameters" newName="parameters_102"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.48.0.seq_end" newName="seq_end_1048"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.2.0.program_file" newName="program_file_102"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.48.0.hit_end" newName="hit_end_1048"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.48.0.evalue" newName="evalue_1048"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.2.0.program" newName="program_102"/>
+		<renamedColumn tableKey="protein_feature" colKey="1.2.0.db" newName="db_102"/>
+		<maskedRelation tableKey="protein_feature" relationId="738"/>
+		<maskedRelation tableKey="protein_feature" relationId="743"/>
+		<maskedRelation tableKey="protein_feature" relationId="746"/>
+		<maskedRelation tableKey="protein_feature" relationId="752"/>
+		<maskedRelation tableKey="protein_feature" relationId="814"/>
+		<maskedRelation tableKey="protein_feature" relationId="818"/>
+	</dataset>
+	<datasetPartitionTable name="object_xref" selectedColumns="db_name_1018">
+		<partitionRegex name="db_name_1018" match="-" replace="_"/>
+		<partitionApplication name="%NAME%" dimension="gene__object_xref" pCols="db_name_1018" dsCols="1.18.0.db_name" nameCols="db_name_1018" compounds="0"/>
+	</datasetPartitionTable>
+	<datasetPartitionTable name="object_xref_copy" selectedColumns="db_name_1018">
+		<partitionRegex name="db_name_1018" match="-" replace="_"/>
+		<partitionApplication name="%NAME%" dimension="transcript__object_xref" pCols="db_name_1018" dsCols="1.18.0.db_name" nameCols="db_name_1018" compounds="0"/>
+	</datasetPartitionTable>
+	<datasetPartitionTable name="attrib_type" selectedColumns="code_106">
+		<partitionApplication name="%NAME%" dimension="transcript__transcript_attrib" pCols="code_106" dsCols="1.6.0.code" relationIds="785" nameCols="code_106" compounds="292"/>
+	</datasetPartitionTable>
+	<datasetPartitionTable name="protein_feature" selectedColumns="logic_name_102">
+		<partitionApplication name="%NAME%" dimension="translation__protein_feature" pCols="logic_name_102" dsCols="1.2.0.logic_name" relationIds="817" nameCols="logic_name_102" compounds="12"/>
+	</datasetPartitionTable>
+	<datasetPartitionTable name="object_xref_copy_1" selectedColumns="db_name_1018">
+		<partitionRegex name="db_name_1018" match="-" replace="_"/>
+		<partitionApplication name="%NAME%" dimension="translation__object_xref" pCols="db_name_1018" dsCols="1.18.0.db_name" nameCols="db_name_1018" compounds="15"/>
+	</datasetPartitionTable>
+	<datasetPartitionTable name="ontology_xref_gene" selectedColumns="db_name_1018">
+		<partitionApplication name="%NAME%" dimension="gene__object_xref_1" pCols="db_name_1018" dsCols="1.18.0.db_name" nameCols="db_name_1018" compounds="1"/>
+	</datasetPartitionTable>
+	<datasetPartitionTable name="ontology_xref_transcript" selectedColumns="db_name_1018">
+		<partitionApplication name="%NAME%" dimension="transcript__object_xref_1" pCols="db_name_1018" dsCols="1.18.0.db_name" relationIds="727" nameCols="db_name_1018" compounds="1"/>
+	</datasetPartitionTable>
+	<datasetPartitionTable name="ontology_xref_translation" selectedColumns="db_name_1018">
+		<partitionApplication name="%NAME%" dimension="translation__object_xref_1" pCols="db_name_1018" dsCols="1.18.0.db_name" nameCols="db_name_1018" compounds="1"/>
+	</datasetPartitionTable>
+	<datasetPartitionTable name="MTMP_probestuff_helper" selectedColumns="array_vendor_and_name_11056">
+		<partitionApplication name="%NAME%" dimension="transcript__MTMP_probestuff_helper" pCols="array_vendor_and_name_11056" dsCols="11.56.0.array_vendor_and_name" relationIds="3087" nameCols="array_vendor_and_name_11056" compounds="0"/>
+	</datasetPartitionTable>
+</mart>


### PR DESCRIPTION
…ild pipeline run. The MySQL limit is 64 indexes and the zebrafish transcript main table was just one index over 64. This required a manual intervention, I dropped the index with lowest cardinality source_1064 (cardinality of 4). Since this column only has one or two values accross all the divisions, I believe this index can be dropped to avoid manual intervention every release. This will buy us a bit of time but it's in no way a long term solution...