### PR TITLE
The Variation team doesn't re-generate the MTMP_variation_set_variati…

### DIFF
--- a/modules/Bio/EnsEMBL/BioMart/CreateMTMPVariation.pm
+++ b/modules/Bio/EnsEMBL/BioMart/CreateMTMPVariation.pm
@@ -26,7 +26,7 @@ use base ('Bio::EnsEMBL::EGPipeline::VariationMart::Base');
 sub param_defaults {
   return {
     'drop_mtmp'         => 0,
-    'drop_mtmp_tv_vsv'   => 0,
+    'drop_mtmp_tv'   => 0,
   };
 }
 

--- a/modules/Bio/EnsEMBL/EGPipeline/PipeConfig/VariationMart_conf.pm
+++ b/modules/Bio/EnsEMBL/EGPipeline/PipeConfig/VariationMart_conf.pm
@@ -55,7 +55,7 @@ sub default_options {
     never_skip_genotypes  => [],
     scratch_dir               => '/scratch',
     drop_mtmp             => 1,
-    drop_mtmp_tv_vsv       => 0,
+    drop_mtmp_tv       => 0,
     snp_indep_tables      => [],
     mart_db_name          => $self->o('division_name').'_snp_mart_'.$self->o('eg_release'),
     sample_threshold      => 0,
@@ -303,7 +303,7 @@ sub pipeline_analyses {
       -module            => 'Bio::EnsEMBL::EGPipeline::VariationMart::CreateMTMPTables',
       -parameters        => {
                               drop_mtmp                => $self->o('drop_mtmp'),
-                              drop_mtmp_tv_vsv          => $self->o('drop_mtmp_tv_vsv'),
+                              drop_mtmp_tv          => $self->o('drop_mtmp_tv'),
                               variation_import_lib     => $self->o('variation_import_lib'),
                               variation_feature_script => $self->o('variation_feature_script'),
                               variation_mtmp_script    => $self->o('variation_mtmp_script'),

--- a/modules/Bio/EnsEMBL/EGPipeline/PipeConfig/VariationMart_eg_conf.pm
+++ b/modules/Bio/EnsEMBL/EGPipeline/PipeConfig/VariationMart_eg_conf.pm
@@ -50,7 +50,7 @@ sub default_options {
     mart_db_name          => $self->o('division_name').'_snp_mart_'.$self->o('eg_release'),
     pipeline_name         => 'variation_mart_'.$self->o('division_name').'_'.$self->o('eg_release'),
     drop_mtmp             => 1,
-    drop_mtmp_tv_vsv       => 0,
+    drop_mtmp_tv       => 0,
     sample_threshold      => 20000,
     population_threshold  => 500,
     optimize_tables       => 1,

--- a/modules/Bio/EnsEMBL/EGPipeline/PipeConfig/VariationMart_ensembl_conf.pm
+++ b/modules/Bio/EnsEMBL/EGPipeline/PipeConfig/VariationMart_ensembl_conf.pm
@@ -50,7 +50,7 @@ sub default_options {
     division_name         => 'vertebrates',
     mart_db_name          => 'snp_mart_'.$self->o('eg_release'),
     drop_mtmp             => 1,
-    drop_mtmp_tv_vsv       => 0,
+    drop_mtmp_tv       => 0,
     sample_threshold      => 0,
     population_threshold  => 500,
     optimize_tables       => 1,

--- a/modules/Bio/EnsEMBL/EGPipeline/VariationMart/Base.pm
+++ b/modules/Bio/EnsEMBL/EGPipeline/VariationMart/Base.pm
@@ -59,7 +59,7 @@ sub get_DBAdaptor {
 }
 
 # Check if a MTMP table already exists
-# MTMP_transcript_variation and MTMP_variation_set_variation are quite
+# MTMP_transcript_variation is really
 # big for some species so if the table is already there keep it
 sub does_table_exist {
   my ($self,$table_name) = @_;
@@ -96,14 +96,14 @@ sub run_script {
   my $drop_mtmp = $self->param_required('drop_mtmp');
   my $variation_import_lib = $self->param_required('variation_import_lib');
   my $scratch_dir = $self->param_required('scratch_dir');
-  my $drop_mtmp_tv_vsv = $self->param_required('drop_mtmp_tv_vsv');
+  my $drop_mtmp_tv = $self->param_required('drop_mtmp_tv');
 
 
   # Drop table if exist and drop_mtmp parameter set to 1
-  # We don't want to drop the MTMP_transcript_variation or MTMP_variation_set_variation tables as they
+  # We don't want to drop the MTMP_transcript_variation table as this table
   # gets automatically renerated by the Transcript variation pipeline for the variarion mart
   if ($drop_mtmp){
-    if (!$drop_mtmp_tv_vsv and (($table eq "transcript_variation") or ($table eq "variation_set_variation"))){
+    if (!$drop_mtmp_tv and $table eq "transcript_variation"){
       1;
     }
     else {

--- a/modules/Bio/EnsEMBL/EGPipeline/VariationMart/CreateMTMPTables.pm
+++ b/modules/Bio/EnsEMBL/EGPipeline/VariationMart/CreateMTMPTables.pm
@@ -26,7 +26,7 @@ use base ('Bio::EnsEMBL::EGPipeline::VariationMart::Base');
 sub param_defaults {
   return {
     'drop_mtmp'         => 0,
-    'drop_mtmp_tv_vsv'   => 0,
+    'drop_mtmp_tv'   => 0,
     'sv_exists'         => 0,
     'regulatory_exists' => 1,
     'motif_exits'       => 1,

--- a/modules/Bio/EnsEMBL/PipeConfig/BuildGeneMartMTMPTables_conf.pm
+++ b/modules/Bio/EnsEMBL/PipeConfig/BuildGeneMartMTMPTables_conf.pm
@@ -47,7 +47,7 @@ sub default_options {
            'run_all'      => 0,
            'base_dir'  => getcwd,
            'registry'      => $self->o('registry'),
-           'drop_mtmp_tv_vsv' => 0,
+           'drop_mtmp_tv' => 0,
            'drop_mtmp_variation'      => 1,
            'drop_mtmp_probestuff'     => 1,
            # The following are required for building MTMP tables.
@@ -131,7 +131,7 @@ sub pipeline_analyses {
       -module            => 'Bio::EnsEMBL::BioMart::CreateMTMPVariation',
       -parameters        => {
                               drop_mtmp               => $self->o('drop_mtmp_variation'),
-                              drop_mtmp_tv_vsv         => $self->o('drop_mtmp_tv_vsv'),
+                              drop_mtmp_tv         => $self->o('drop_mtmp_tv'),
                               variation_import_lib     => $self->o('variation_import_lib'),
                               variation_feature_script => $self->o('variation_feature_script'),
                               variation_mtmp_script    => $self->o('variation_mtmp_script'),


### PR DESCRIPTION
…on consistently anymore, they usually patch the variation_set table directly. This is dangerous for this pipeline as we are likely to end up with inconsistency and need to rebuild the mart table from scratch.Also renamed drop_mtmp_tv_vsv to drop_mtmp_tv to match changes