### PR TITLE
New check for empty variation database where the data is pulled by th…

### DIFF
--- a/scripts/create_martbuilder_file.pl
+++ b/scripts/create_martbuilder_file.pl
@@ -159,7 +159,10 @@ sub get_list {
             }
             # Get variation and funcgen databases
             elsif ($database->type eq "variation"){
-                push (@variation, $mart_name);
+                # We now have empty variation databases linked to VCF files like chlorocebus_sabaeus
+                if ($genome->has_variations()){
+                    push (@variation, $mart_name);
+                }
             }
             elsif ($database->type eq "funcgen"){
                 push (@funcgen, $mart_name);


### PR DESCRIPTION
…e Variation API from a VCF files. We can't build mart on these so we need to exclude them.
This code works because we do store the variation database in the metadata db but since we can't get any variation stats for it, the genome has_variation flag is set to 0.