### PR TITLE
Dog strains fix

### DIFF
--- a/modules/Bio/EnsEMBL/BioMart/Mart.pm
+++ b/modules/Bio/EnsEMBL/BioMart/Mart.pm
@@ -89,7 +89,7 @@ sub genome_to_exclude {
 	else{
 		$filename = $FindBin::Bin.'/exclude_'.$division.'.ini';
 	}
-	@excluded_species = read_file( $filename,chomp => 1) if -e $filename;
+	@excluded_species = read_file( $filename,chomp => 1);
 	return \@excluded_species;
 }
 

--- a/modules/Bio/EnsEMBL/EGPipeline/PipeConfig/VariationMart_conf.pm
+++ b/modules/Bio/EnsEMBL/EGPipeline/PipeConfig/VariationMart_conf.pm
@@ -288,6 +288,7 @@ sub pipeline_analyses {
                               never_skip_genotypes  => $self->o('never_skip_genotypes'),
                               division_name         => $self->o('division_name'),
                               species_suffix      => $self->o('species_suffix'),
+                              ensembl_cvs_root_dir => $self->o('ensembl_cvs_root_dir')
                             },
       -max_retry_count   => 0,
       -rc_name           => 'normal',

--- a/modules/Bio/EnsEMBL/EGPipeline/VariationMart/CopyOrGenerate.pm
+++ b/modules/Bio/EnsEMBL/EGPipeline/VariationMart/CopyOrGenerate.pm
@@ -20,8 +20,9 @@ package Bio::EnsEMBL::EGPipeline::VariationMart::CopyOrGenerate;
 
 use strict;
 use warnings;
-
 use base ('Bio::EnsEMBL::EGPipeline::VariationMart::Base');
+use MartUtils;
+use Bio::EnsEMBL::BioMart::Mart qw(genome_to_exclude);
 
 sub param_defaults {
   return {
@@ -45,10 +46,20 @@ sub write_output {
   my $copy_all          = $self->param('copy_all');
   my $division_name     = $self->param('division_name');
   my $species_suffix    = $self->param('species_suffix');
+  my $ensembl_cvs_root_dir = $self->param('ensembl_cvs_root_dir');
   my $mart_table_prefix;
-  
-  $species =~ /^(.)[^_]+_?([a-z0-9])?[a-z0-9]+?_([a-z0-9]+)$/;
-  $mart_table_prefix = defined $2 ? "$1$2$3" : "$1$3";
+  my $excluded_species;
+  # Use division to find the release in metadata database
+  if ($division_name eq "vertebrates"){
+    # Load species to exclude from the Vertebrates marts
+    $excluded_species = genome_to_exclude($division_name,$ensembl_cvs_root_dir);
+  }
+  if (grep( /$species/, @$excluded_species) ){
+    return;
+  }
+
+  my $database = $self->get_DBAdaptor('core')->dbc()->dbname;
+  $mart_table_prefix = generate_dataset_name_from_db_name($database);
   
   if ($species_suffix ne '') {
     $mart_table_prefix .= $species_suffix;

--- a/modules/Bio/EnsEMBL/EGPipeline/VariationMart/DropMartTables.pm
+++ b/modules/Bio/EnsEMBL/EGPipeline/VariationMart/DropMartTables.pm
@@ -22,6 +22,7 @@ use strict;
 use warnings;
 
 use base ('Bio::EnsEMBL::EGPipeline::VariationMart::Base');
+use MartUtils;
 
 sub run {
   my ($self) = @_;
@@ -29,8 +30,8 @@ sub run {
   my $species = $self->param_required('species');
   
   if ($self->param('drop_mart_tables')) {
-    $species =~ /^(\w).+_(\w+)$/;
-    my $mart_table_prefix = "$1$2_eg";
+    my $database = $self->get_DBAdaptor('core')->dbc()->dbname;
+    my $mart_table_prefix = generate_dataset_name_from_db_name($database);
     
     my $mart_dbh = $self->mart_dbh();
     

--- a/modules/MartUtils.pm
+++ b/modules/MartUtils.pm
@@ -101,7 +101,6 @@ sub generate_dataset_name_from_db_name {
             if ($dataset =~ m/$full_name/){
                 $dataset =~ s/$full_name/$alias/g;
             }
-            print $dataset."\n";
         }
         if (length($dataset) > 18) {
             die "$dataset name is too long. Add a new key to the name_substitution hash for this species $database\n";

--- a/scripts/pre_configuration_mart_healthcheck.pl
+++ b/scripts/pre_configuration_mart_healthcheck.pl
@@ -428,8 +428,10 @@ sub metadata_species_list {
   ($rdba,$gdba,$release,$release_info) = fetch_and_set_release($newrel,$rdba,$gdba);
   #Get both division short and full name from a division short or full name
   my ($division,$division_name)=process_division_names($div);
-  # Load species to exclude from the Vertebrates marts
-  $excluded_species = genome_to_exclude($division_name);
+  if ($division eq "vertebrates"){
+    # Load species to exclude from the Vertebrates marts
+    $excluded_species = genome_to_exclude($division_name);
+  }
   # Get all the genomes for a given division and release
   my $genomes = $gdba->fetch_all_by_division($division_name);
   foreach my $genome (@$genomes){


### PR DESCRIPTION
We have issues with the two new dog strains added in release 99: canis_lupus_familiarisgreatdane and Canis_lupus_familiarisbasenji as their dataset name is too long it exceed the MySQL limit of 64 char, e.g: clfamiliarisbasenji_gene_ensembl__ox_RefSeq_peptide_predicted__dm. I have added a new check to make sure a dataset is not longer than 18 char by looking at the largest table name we have and current dataset name. If this is the case, the gene mart java code won't be able to generate this table dataset_gene_ensembl__protein_feature_superfamily__dm as it will exceed the 64 char from MySQL. We are using a name_substitution hash to rename species to something that still make sense to the user.