### PR TITLE
Compara empty data fix

### DIFF
--- a/scripts/templates/gene_template_template.xml
+++ b/scripts/templates/gene_template_template.xml
@@ -1382,7 +1382,7 @@
         </FilterDescription>
       </FilterCollection>
     </FilterGroup>
-    <FilterGroup description="Filter on multi species comparison relationships" displayName="MULTI SPECIES COMPARISONS:" hidden="false" internalName="multispecies" useDefault="true">
+    <FilterGroup description="Filter on multi species comparison relationships" displayName="MULTI SPECIES COMPARISONS:" hidden="false" internalName="multispecies" useDefault="true" checkTable="homolog_">
       <FilterCollection displayName="Homologue filters" hidden="false" internalName="homolog_filter_collection" useDefault="true">
         <FilterDescription displayType="container" hidden="false" internalName="homolog_filters" type="boolean_list" useDefault="true">
           <Replace id="homology_filters"/>
@@ -1393,10 +1393,6 @@
       <FilterCollection displayName="Limit to genes ..." internalName="family_domain_id" useDefault="true">
         <FilterDescription displayType="container" internalName="id_list_protein_domain_and_feature_filters" type="boolean_list" useDefault="true">
            <Option key="translation_id_1068_key" displayName="With Interpro ID(s)" displayType="list" field="interpro_bool" hidden="false" internalName="with_interpro" isSelectable="true" legal_qualifiers="only,excluded" qualifier="only" style="radio" tableConstraint="main" type="boolean">
-            <Option displayName="Only" hidden="false" internalName="only" value="only" />
-            <Option displayName="Excluded" hidden="false" internalName="excluded" value="excluded" />
-          </Option>
-          <Option key="translation_id_1068_key" displayName="With Ensembl Protein Family ID(s)" displayType="list" field="family_bool" hidden="false" internalName="with_family" isSelectable="true" legal_qualifiers="only,excluded" qualifier="only" style="radio" tableConstraint="main" type="boolean">
             <Option displayName="Only" hidden="false" internalName="only" value="only" />
             <Option displayName="Excluded" hidden="false" internalName="excluded" value="excluded" />
           </Option>
@@ -1843,7 +1839,7 @@
       </AttributeCollection>
     </AttributeGroup>
   </AttributePage>
-  <AttributePage displayName="Homologues (Max select 6 orthologues)" hidden="false" internalName="homologs" outFormats="html,txt,csv,tsv,xls" useDefault="true">
+  <AttributePage displayName="Homologues (Max select 6 orthologues)" hidden="false" internalName="homologs" outFormats="html,txt,csv,tsv,xls" useDefault="true" checkTable="homolog_">
     <AttributeGroup description="Features of Genes" displayName="GENE:" hidden="false" internalName="gene" useDefault="true">
       <AttributeCollection description="Ensembl Annotated Attributes and Features" displayName="Ensembl" hidden="false" internalName="ensembl_attributes" useDefault="true">
         <AttributeDescription hidden="false" internalName="homologs_ensembl_gene_id" pointerAttribute="ensembl_gene_id" pointerDataset="*species4*" pointerInterface="default" useDefault="true"/>

--- a/scripts/tidy_tables.pl
+++ b/scripts/tidy_tables.pl
@@ -105,7 +105,10 @@ else {
   %columns_to_tidy = (
                '%\_\_gene\_\_main'    => ['display_label_1074','db_display_name_1018','phenotype_bool','version_1020'],
                '%\_\_transcript\_\_main'    => ['display_label_1074_r1','db_display_name_1018_r1','phenotype_bool','version_1064','version_1020'],
-               '%\_\_translation\_\_main'    => ['stable_id_408','description_408','family_bool','phenotype_bool','version_1064','version_1020','version_1068']
+               '%\_\_translation\_\_main'    => ['stable_id_408','description_408','family_bool','phenotype_bool','version_1064','version_1020','version_1068'],
+							 '%\_\_homolog\_%\_\_dm'  => ['dn_4014','ds_4014','goc_score_4014','wga_coverage_4014','is_high_confidence_4014'],
+							 '%\_\_paralog\_%\_\_dm' => ['dn_4014','ds_4014','is_high_confidence_4014'],
+							 '%\_\_homoeolog\_%\_\_dm' => ['dn_4014','ds_4014','is_high_confidence_4014']
   );
 }
 


### PR DESCRIPTION
Related to tickets ENSPROD-4396 and ENSPROD-4793.
Dropping columns that can be empty from homologs, paralogs and homoeolog tables
Removing compara attributes if these have been cleaned up by the tidy script. Hiding homologs filter and attributes if the data doesn't exist. Hiding Ensembl Family data filters if the data doesn't exist.

