### PR TITLE
The Genebuild team have removed the list of species to exclude and re…

### DIFF
--- a/modules/Bio/EnsEMBL/BioMart/Mart.pm
+++ b/modules/Bio/EnsEMBL/BioMart/Mart.pm
@@ -28,7 +28,7 @@ use File::Slurp;
 use base qw(Bio::EnsEMBL::BioMart::MartServiceObject);
 use Bio::EnsEMBL::MetaData::Base qw(process_division_names);
 use Exporter qw/import/;
-our @EXPORT_OK = qw(genome_to_exclude);
+our @EXPORT_OK = qw(genome_to_include);
 
 sub new {
 	my ( $proto, @args ) = @_;
@@ -77,20 +77,20 @@ sub get_dataset_by_name {
 	return $dataset;
 }
 
-sub genome_to_exclude {
+sub genome_to_include {
 	my ($div,$base_dir) = @_;
 	#Get both division short and full name from a division short or full name
 	my ($division,$division_name)=process_division_names($div);
 	my $filename;
-	my @excluded_species;
+	my @included_species;
 	if (defined $base_dir){
-		$filename = $base_dir.'/ensembl-biomart/scripts/exclude_'.$division.'.ini';
+		$filename = $base_dir.'/ensembl-biomart/scripts/include_'.$division.'.ini';
 	}
 	else{
-		$filename = $FindBin::Bin.'/exclude_'.$division.'.ini';
+		$filename = $FindBin::Bin.'/include_'.$division.'.ini';
 	}
-	@excluded_species = read_file( $filename,chomp => 1);
-	return \@excluded_species;
+	@included_species = read_file( $filename,chomp => 1);
+	return \@included_species;
 }
 
 1;

--- a/modules/Bio/EnsEMBL/BioMart/SequenceDatasetFactory.pm
+++ b/modules/Bio/EnsEMBL/BioMart/SequenceDatasetFactory.pm
@@ -12,7 +12,7 @@ use Bio::EnsEMBL::DBSQL::DBConnection;
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::ApiVersion qw/software_version/;
 use MartUtils;
-use Bio::EnsEMBL::BioMart::Mart qw(genome_to_exclude);
+use Bio::EnsEMBL::BioMart::Mart qw(genome_to_include);
 
 sub run {
   my $self    = shift @_;
@@ -62,15 +62,15 @@ create table if not exists $mart.dataset_names (
   my $output_ids = [];
   my $division   = $self->param('division');
   my $pId;
-  #List of species to exclude from the sequence mart
-  my $excluded_species;
+  #List of species to include in the vertebreates sequence mart
+  my $included_species;
   if    ( $division eq 'EnsemblProtists' ) { $pId = 10000; }
   elsif ( $division eq 'EnsemblPlants' )   { $pId = 20000; }
   elsif ( $division eq 'EnsemblMetazoa' ) { $pId = 30000;  }
   elsif ( $division eq 'EnsemblFungi' )    { $pId = 40000;  }
   elsif ( $division eq 'Vectorbase' ) { $pId = 50000; }
   elsif ( $division eq 'Parasite' )   { $pId = 60000 }
-  elsif ( $division eq 'EnsemblVertebrates' ) { $pId = 0; $excluded_species = genome_to_exclude($division,$self->param('base_dir'));}
+  elsif ( $division eq 'EnsemblVertebrates' ) { $pId = 0; $included_species = genome_to_include($division,$self->param('base_dir'));}
 
   for my $dba ( @{$dbas} ) {
 
@@ -86,7 +86,9 @@ create table if not exists $mart.dataset_names (
     # Excluding species from the sequence mart for vertebrates
     if ($division eq 'EnsemblVertebrates'){
       my $production_name  = $dba->get_MetaContainer()->get_production_name();
-      if (grep( /$production_name/, @$excluded_species) ){
+      # In the vertebrates sequence mart we want to include the mouse strains for the mouse mart
+      if (!grep( /$production_name/, @$included_species) and $production_name !~ m/^mus_musculus_/){
+        $self->warning("Excluding $production_name from sequence mart");
         $dba->dbc()->disconnect_if_idle();
         next;
       }

--- a/modules/Bio/EnsEMBL/EGPipeline/VariationMart/CopyOrGenerate.pm
+++ b/modules/Bio/EnsEMBL/EGPipeline/VariationMart/CopyOrGenerate.pm
@@ -22,7 +22,7 @@ use strict;
 use warnings;
 use base ('Bio::EnsEMBL::EGPipeline::VariationMart::Base');
 use MartUtils;
-use Bio::EnsEMBL::BioMart::Mart qw(genome_to_exclude);
+use Bio::EnsEMBL::BioMart::Mart qw(genome_to_include);
 
 sub param_defaults {
   return {
@@ -48,13 +48,14 @@ sub write_output {
   my $species_suffix    = $self->param('species_suffix');
   my $ensembl_cvs_root_dir = $self->param('ensembl_cvs_root_dir');
   my $mart_table_prefix;
-  my $excluded_species;
+  my $included_species;
   # Use division to find the release in metadata database
   if ($division_name eq "vertebrates"){
     # Load species to exclude from the Vertebrates marts
-    $excluded_species = genome_to_exclude($division_name,$ensembl_cvs_root_dir);
+    $included_species = genome_to_include($division_name,$ensembl_cvs_root_dir);
   }
-  if (grep( /$species/, @$excluded_species) ){
+  if (!grep( /$species/, @$included_species) ){
+    $self->warning("Excluding $species from variation mart");
     return;
   }
 

--- a/scripts/pre_configuration_mart_healthcheck.pl
+++ b/scripts/pre_configuration_mart_healthcheck.pl
@@ -20,7 +20,7 @@ use POSIX;
 use Bio::EnsEMBL::MetaData::DBSQL::MetaDataDBAdaptor;
 use Bio::EnsEMBL::MetaData::Base qw(process_division_names fetch_and_set_release);
 use MartUtils;
-use Bio::EnsEMBL::BioMart::Mart qw(genome_to_exclude);
+use Bio::EnsEMBL::BioMart::Mart qw(genome_to_include);
 
 
 my ( $old_dbname, $olduser,    $oldpass, $oldhost,
@@ -420,14 +420,14 @@ sub metadata_species_list {
   my $rdba = $dba->get_DataReleaseInfoAdaptor();
   my %metadata_species_core;
   my %metadata_species_variation;
-  my ($release,$release_info,$excluded_species);
+  my ($release,$release_info,$included_species);
   # Get the release version
   ($rdba,$gdba,$release,$release_info) = fetch_and_set_release($newrel,$rdba,$gdba);
   #Get both division short and full name from a division short or full name
   my ($division,$division_name)=process_division_names($div);
   if ($division eq "vertebrates"){
-    # Load species to exclude from the Vertebrates marts
-    $excluded_species = genome_to_exclude($division_name);
+    # Load species to include in the Vertebrates marts
+    $included_species = genome_to_include($division_name);
   }
   # Get all the genomes for a given division and release
   my $genomes = $gdba->fetch_all_by_division($division_name);
@@ -443,9 +443,9 @@ sub metadata_species_list {
         next;
     }
     # For Vertebrates, we are excluding some species from the marts
-    if ($division eq "vertebrates"){
+    if ($division eq "vertebrates" and $new_dbname !~ "mouse_mart"){
         my $genome_name = $genome->name();
-        if (grep( /$genome_name/, @$excluded_species) ){
+        if (!grep( /$genome_name/, @$included_species) ){
             next;
         }
     }


### PR DESCRIPTION
…place it with the inverse meaning a list of species to include: https://github.com/Ensembl/ensembl-biomart/pull/93. If a species is not in this list then it should not be in the vertebrates mart. The create_martbuilder_file.pl, variation and sequence mart pipelines will report species excluded from the build. A hack is in place in sequence and create_martbuilder_file.pl to be able to deal with the mouse mart which only contains the mouse strains and the sequence mart which is shared between the mouse mart and vert gene mart.