### PR TITLE
Exclude species mtmp

### DIFF
--- a/modules/Bio/EnsEMBL/BioMart/CheckExcludedSpecies.pm
+++ b/modules/Bio/EnsEMBL/BioMart/CheckExcludedSpecies.pm
@@ -1,0 +1,52 @@
+=head1 LICENSE
+
+Copyright [2009-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package Bio::EnsEMBL::BioMart::CheckExcludedSpecies;
+
+use strict;
+use warnings;
+use base ('Bio::EnsEMBL::EGPipeline::VariationMart::Base');
+use MartUtils;
+use Bio::EnsEMBL::BioMart::Mart qw(genome_to_include);
+use Bio::EnsEMBL::MetaData::Base qw(process_division_names);
+
+sub run {
+  my ($self) = @_;
+  my $div     = $self->param('division');
+  my $species           = $self->param_required('species');
+  my $base_dir          = $self->param('base_dir');
+  my $included_species;
+  my ($division,$division_name)=process_division_names($div);
+  # Use division to find the release in metadata database
+  if ($division_name eq "vertebrates"){
+    # Load species to exclude from the Vertebrates marts
+    $included_species = genome_to_include($division_name,$base_dir);
+    if (!grep( /$species/, @$included_species) ){
+      $self->warning("Excluding $species from mart");
+      return;
+    }
+  }
+  $self->dataflow_output_id({
+    'species'          => $species
+  }, 4);
+  $self->dataflow_output_id({
+    'species'          => $species
+  }, 6);
+}
+
+1;

--- a/modules/Bio/EnsEMBL/EGPipeline/VariationMart/CopyOrGenerate.pm
+++ b/modules/Bio/EnsEMBL/EGPipeline/VariationMart/CopyOrGenerate.pm
@@ -53,10 +53,10 @@ sub write_output {
   if ($division_name eq "vertebrates"){
     # Load species to exclude from the Vertebrates marts
     $included_species = genome_to_include($division_name,$ensembl_cvs_root_dir);
-  }
-  if (!grep( /$species/, @$included_species) ){
-    $self->warning("Excluding $species from variation mart");
-    return;
+    if (!grep( /$species/, @$included_species) ){
+      $self->warning("Excluding $species from variation mart");
+      return;
+    }
   }
 
   my $database = $self->get_DBAdaptor('core')->dbc()->dbname;

--- a/modules/Bio/EnsEMBL/PipeConfig/BuildGeneMartMTMPTables_conf.pm
+++ b/modules/Bio/EnsEMBL/PipeConfig/BuildGeneMartMTMPTables_conf.pm
@@ -110,7 +110,33 @@ sub pipeline_analyses {
       -max_retry_count => 0,
       -rc_name         => 'normal',
       -flow_into       => {
+                            '4' => 'CheckExcludedSpeciesVariation',
+                            '6' => 'CheckExcludedSpeciesRegulation',
+                          }
+    },
+    {
+      -logic_name      => 'CheckExcludedSpeciesVariation',
+      -module          => 'Bio::EnsEMBL::BioMart::CheckExcludedSpecies',
+      -max_retry_count => 0,
+      -parameters        => {
+                        base_dir     => $self->o('base_dir'),
+                        division    => $self->o('division'),
+                      },
+      -rc_name         => 'normal',
+      -flow_into       => {
                             '4' => 'CreateMTMPVariation',
+                          }
+    },
+    {
+      -logic_name      => 'CheckExcludedSpeciesRegulation',
+      -module          => 'Bio::EnsEMBL::BioMart::CheckExcludedSpecies',
+      -max_retry_count => 0,
+      -parameters        => {
+                        base_dir     => $self->o('base_dir'),
+                        division    => $self->o('division'),
+                      },
+      -rc_name         => 'normal',
+      -flow_into       => {
                             '6' => 'CreateMTMPProbestuffHelper',     
                           }
     },


### PR DESCRIPTION
Making sure we don't create MTMP tables for species that are excluded from the vertebrates marts. Fixed bug with non-vertebrates were nothing would flow because of empty list of included species.