### PR TITLE
Fix human somatic

### DIFF
--- a/modules/Bio/EnsEMBL/BioMart/SequenceDatasetFactory.pm
+++ b/modules/Bio/EnsEMBL/BioMart/SequenceDatasetFactory.pm
@@ -11,7 +11,7 @@ use Bio::EnsEMBL::DBSQL::DBAdaptor;
 use Bio::EnsEMBL::DBSQL::DBConnection;
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::ApiVersion qw/software_version/;
-use MartUtils;
+use MartUtils qw(generate_dataset_name_from_db_name);
 use Bio::EnsEMBL::BioMart::Mart qw(genome_to_include);
 
 sub run {

--- a/modules/Bio/EnsEMBL/EGPipeline/PipeConfig/VariationMart_conf.pm
+++ b/modules/Bio/EnsEMBL/EGPipeline/PipeConfig/VariationMart_conf.pm
@@ -154,6 +154,10 @@ sub default_options {
       'snp__mart_transcript_variation__dm'     => ['polyphen_score_2090','sift_score_2090'],
     },
 
+    snp_som_cull_columns => {
+      'snp_som__mart_transcript_variation__dm'   => ['pep_allele_string_2090','polyphen_prediction_2090','polyphen_score_2090','sift_prediction_2090','sift_score_2090'],
+    },
+
     snp_som_cull_tables => {
       'snp_som__population_genotype__dm'     => 'name_2019',
       'snp_som__variation_annotation__dm'    => 'name_2021',
@@ -459,6 +463,7 @@ sub pipeline_analyses {
       -parameters        => {
                               snp_cull_tables => $self->o('snp_cull_tables'),
                               snp_cull_columns => $self->o('snp_cull_columns'),
+                              snp_som_cull_columns => $self->o('snp_som_cull_columns'),
                               snp_som_cull_tables => $self->o('snp_som_cull_tables'), 
                               sv_cull_tables  => $self->o('sv_cull_tables'),
                               sv_som_cull_tables => $self->o('sv_som_cull_tables'),

--- a/modules/Bio/EnsEMBL/EGPipeline/VariationMart/CullMartTables.pm
+++ b/modules/Bio/EnsEMBL/EGPipeline/VariationMart/CullMartTables.pm
@@ -45,6 +45,13 @@ sub run {
     foreach my $table (keys %snp_som_cull_tables) {
       $self->cull_table($table, $snp_som_cull_tables{$table});
     }
+    my %snp_som_cull_columns = %{$self->param_required('snp_som_cull_columns')};
+    foreach my $table (keys %snp_som_cull_columns) {
+      foreach my $column (@{$snp_som_cull_columns{$table}})
+      {
+        $self->cull_column($table, $column);
+      }
+    }
   }
 
   

--- a/modules/Bio/EnsEMBL/EGPipeline/VariationMart/DropMartTables.pm
+++ b/modules/Bio/EnsEMBL/EGPipeline/VariationMart/DropMartTables.pm
@@ -22,7 +22,7 @@ use strict;
 use warnings;
 
 use base ('Bio::EnsEMBL::EGPipeline::VariationMart::Base');
-use MartUtils;
+use MartUtils qw(generate_dataset_name_from_db_name);
 
 sub run {
   my ($self) = @_;

--- a/modules/MartUtils.pm
+++ b/modules/MartUtils.pm
@@ -31,7 +31,7 @@ use Carp;
 use Log::Log4perl qw(:easy);
 use DbiUtils;
 use Exporter qw/import/;
-our @EXPORT_OK = qw(generate_dataset_name_from_db_name);
+our @EXPORT_OK = qw(get_ensembl_db get_ensembl_db_collection get_ensembl_db_single_parasite get_dataset_names get_species_name_for_dataset get_sql_name_for_dataset generate_dataset_name_from_db_name get_datasets get_ensembl_db_single);
 
 #sub get_species_name_for_dataset {
 #    my ($dbh,$ds_name) = @_;

--- a/scripts/add_compara.pl
+++ b/scripts/add_compara.pl
@@ -25,7 +25,7 @@ use Log::Log4perl qw(:easy);
 use FindBin;
 use lib "$FindBin::Bin/../modules";
 use DbiUtils;
-use MartUtils;
+use MartUtils qw(get_dataset_names get_species_name_for_dataset get_sql_name_for_dataset);
 use Cwd;
 use File::Copy;
 use Getopt::Long;

--- a/scripts/add_compara_bool.pl
+++ b/scripts/add_compara_bool.pl
@@ -30,7 +30,7 @@ use Log::Log4perl qw(:easy);
 use FindBin;
 use lib "$FindBin::Bin/../modules";
 use DbiUtils;
-use MartUtils;
+use MartUtils qw(get_dataset_names get_species_name_for_dataset get_sql_name_for_dataset);
 use Cwd;
 use File::Copy;
 use Getopt::Long;

--- a/scripts/calculate_sequence_data.pl
+++ b/scripts/calculate_sequence_data.pl
@@ -31,7 +31,7 @@ use Data::Dumper;
 use FindBin;
 use lib "$FindBin::Bin/../modules";
 use DbiUtils;
-use MartUtils;
+use MartUtils qw(get_dataset_names get_sql_name_for_dataset);
 use Getopt::Long;
 use Bio::EnsEMBL::Registry;
 

--- a/scripts/create_martbuilder_file.pl
+++ b/scripts/create_martbuilder_file.pl
@@ -27,7 +27,7 @@ use Data::Dumper;
 use Bio::EnsEMBL::Utils::CliHelper;
 use Carp;
 use Bio::EnsEMBL::MetaData::DBSQL::MetaDataDBAdaptor;
-use MartUtils;
+use MartUtils qw(generate_dataset_name_from_db_name);
 use Bio::EnsEMBL::BioMart::Mart qw(genome_to_include);
 
 my $cli_helper = Bio::EnsEMBL::Utils::CliHelper->new();

--- a/scripts/generate_external_synonym.pl
+++ b/scripts/generate_external_synonym.pl
@@ -6,7 +6,7 @@ use DBI;
 use Getopt::Long qw(:config no_ignore_case);
 use Bio::EnsEMBL::Registry;
 use DbiUtils;
-use MartUtils;
+use MartUtils qw(get_sql_name_for_dataset);
 use Log::Log4perl qw(:easy);
 
 

--- a/scripts/generate_names.pl
+++ b/scripts/generate_names.pl
@@ -30,7 +30,7 @@ use List::MoreUtils qw(any);
 use FindBin;
 use lib "$FindBin::Bin/../modules";
 use DbiUtils;
-use MartUtils;
+use MartUtils qw(get_ensembl_db get_ensembl_db_single_parasite get_datasets get_ensembl_db_single);
 use Getopt::Long;
 use POSIX;
 use Bio::EnsEMBL::Registry;

--- a/scripts/pre_configuration_mart_healthcheck.pl
+++ b/scripts/pre_configuration_mart_healthcheck.pl
@@ -19,7 +19,7 @@ use DBI;
 use POSIX;
 use Bio::EnsEMBL::MetaData::DBSQL::MetaDataDBAdaptor;
 use Bio::EnsEMBL::MetaData::Base qw(process_division_names fetch_and_set_release);
-use MartUtils;
+use MartUtils qw(generate_dataset_name_from_db_name);
 use Bio::EnsEMBL::BioMart::Mart qw(genome_to_include);
 
 

--- a/scripts/split_mart.pl
+++ b/scripts/split_mart.pl
@@ -30,7 +30,7 @@ use Data::Dumper;
 use FindBin;
 use lib "$FindBin::Bin/../modules";
 use DbiUtils;
-use MartUtils;
+use MartUtils qw(get_ensembl_db get_ensembl_db_collection get_datasets);
 use Getopt::Long qw(:config no_ignore_case);
 use Log::Log4perl qw(:easy);
 

--- a/scripts/tidy_tables.pl
+++ b/scripts/tidy_tables.pl
@@ -79,18 +79,7 @@ $mart_handle->do("use $mart_db");
 my %tables_to_tidy;
 my %columns_to_tidy;
 
-if ($mart_db =~ /snp_mart/) {
-  %tables_to_tidy = (
-				 '%\_\_mpoly\_\_dm'                   =>  ['name_2019'],
-				 '%\_\_variation\_set\_variation\_\_dm' => ['description_2077'],
-				 '%snp\_\_variation\_annotation\_\_dm'    => ['description_2033','name_2021'],
-				 '%structural\_\_variation\_annotation\_\_dm'    => ['name_2019','description_2019'],
-      );
-  %columns_to_tidy = (
-  	             '%snp\_\_mart\_transcript\_variation\_\_dm'    => ['sift_score_2090','polyphen_score_2090'],
-  	);
-}
-elsif ($mart_db =~ /ontology_mart/) {
+if ($mart_db =~ /ontology_mart/) {
   %tables_to_tidy = (
 				 'closure\_%\_\_closure__main' => ['name_302']
   );
@@ -103,6 +92,7 @@ else {
 			   '%\_\ox\_%\_\_dm'               => ['dbprimary_acc_1074'],
 			   '%\_\_phenotype\_\_dm'       => ['description_20125']);
   %columns_to_tidy = (
+					     '%\_transcript\_variation\_som\_\_dm' => ['seq_region_start_2026','clinical_significance_2025','minor_allele_2025','minor_allele_count_2025','minor_allele_freq_2025','pep_allele_string_2076','polyphen_prediction_2076','polyphen_score_2076','sift_prediction_2076','sift_score_2076'],
                '%\_\_gene\_\_main'    => ['display_label_1074','db_display_name_1018','phenotype_bool','version_1020'],
                '%\_\_transcript\_\_main'    => ['display_label_1074_r1','db_display_name_1018_r1','phenotype_bool','version_1064','version_1020'],
                '%\_\_translation\_\_main'    => ['stable_id_408','description_408','family_bool','phenotype_bool','version_1064','version_1020','version_1068'],


### PR DESCRIPTION
Updated tidy script to cleanup some columns for somatic data that are now empty. The data will come back in the future. Removed snp mart commands since these are now done in CullMartTables module
Updated module to cleanup some columns for somatic data that are now empty. The data will come back in the future.
Fixed issue introduced by making MartUtils a package, we now need to export the subroutines and import them from our various scripts
