### PR TITLE
Adding mart integrity test pre_configuration_mart_healthcheck.pl afte…

### DIFF
--- a/modules/Bio/EnsEMBL/EGPipeline/PipeConfig/VariationMart_conf.pm
+++ b/modules/Bio/EnsEMBL/EGPipeline/PipeConfig/VariationMart_conf.pm
@@ -67,6 +67,15 @@ sub default_options {
     species_suffix        => '',
     max_dropdown          => '20000',
     genomic_features_dbname => '',
+    olduser   => undef,
+    oldport   => undef,
+    oldhost   => undef,
+    test_dir => '/hps/nobackup2/production/ensembl/'.$self->o('ENV', 'USER').'/mart_test',
+    old_mart => undef,
+    old_release => undef,
+    new_release => undef,
+    grch37 => 0,
+
 
     
     previous_mart => {
@@ -570,8 +579,45 @@ sub pipeline_analyses {
                               optimize_tables => $self->o('optimize_tables'),
                             },
       -max_retry_count   => 0,
+      -flow_into    => 'run_tests',
       -rc_name           => 'normal',
     },
+    { -logic_name  => 'run_tests',
+        -module      => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+        -meadow_type => 'LSF',
+        -flow_into    => 'check_tests',
+        -parameters  => {
+                         'cmd' =>
+                         'cd #test_dir#;perl #base_dir#/ensembl-biomart/scripts/pre_configuration_mart_healthcheck.pl -newuser #user# -newpass #pass# -newport #port# -newhost #host# -olduser #olduser# -oldport #oldport# -oldhost #oldhost# -new_dbname #mart# -old_dbname #old_mart# -old_rel #old_release# -new_rel #new_release# -empty_column 1 -grch37 #grch37#',
+                         'mart'   => $self->o('mart'),
+                         'user'     => $self->o('user'),
+                         'pass'     => $self->o('pass'),
+                         'host'     => $self->o('host'),
+                         'port'     => $self->o('port'),
+                         'olduser'     => $self->o('olduser'),
+                         'oldhost'     => $self->o('oldhost'),
+                         'oldport'     => $self->o('oldport'),
+                         'old_mart'     => $self->o('old_mart'),
+                         'test_dir'    => $self->o('test_dir'),
+                         'old_release' => $self->o('old_release'),
+                         'new_release' => $self->o('new_release'),
+                         'base_dir' => $self->o('ensembl_cvs_root_dir'),
+                         'grch37' => $self->o('grch37') },
+        -analysis_capacity => 1 },
+      { -logic_name  => 'check_tests',
+        -module      => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+        -meadow_type => 'LSF',
+        -max_retry_count   => 0,
+        -parameters  => {
+                         'cmd' =>
+                         'EXIT_CODE=0;failed_tests=`find #test_dir#/#old_mart#_#oldhost#_vs_#mart#_#host#.* -type f ! -empty -print`;if [ -n "$failed_tests" ]; then >&2 echo "Some tests have failed please check ${failed_tests}";EXIT_CODE=1;fi;exit $EXIT_CODE',
+                         'mart'   => $self->o('mart'),
+                         'host'     => $self->o('host'),
+                         'oldhost'     => $self->o('oldhost'),
+                         'old_mart'     => $self->o('old_mart'),
+                         'test_dir'    => $self->o('test_dir'),
+        -analysis_capacity => 1 },
+      }
 
   ];
 }

--- a/modules/Bio/EnsEMBL/PipeConfig/BuildMart_conf.pm
+++ b/modules/Bio/EnsEMBL/PipeConfig/BuildMart_conf.pm
@@ -59,6 +59,9 @@ sub default_options {
            'pass'      => undef,
            'port'      => undef,
            'host'      => undef,
+           'olduser'   => undef,
+           'oldport'   => undef,
+           'oldhost'   => undef,
            'mart'      => undef,
            'datasets'  => [],
            'compara'   => undef,
@@ -75,6 +78,11 @@ sub default_options {
            'species'      => [],
            'antispecies'  => [],
            'partition_size' => 1000,
+           'test_dir' => '/hps/nobackup2/production/ensembl/'.$self->o('ENV', 'USER').'/mart_test',
+           'old_mart' => undef,
+           'old_release' => undef,
+           'new_release' => undef,
+           'grch37' => 0,
 
     concat_columns => {
       'gene__main'     => ['stable_id_1023','version_1020'],
@@ -100,6 +108,16 @@ sub pipeline_wide_parameters {
       } # here we inherit anything from the base class, then add our own stuff
   };
 }
+
+sub pipeline_create_commands {
+  my ($self) = @_;
+
+  return [
+    @{$self->SUPER::pipeline_create_commands},
+    'mkdir -p '.$self->o('test_dir'),
+  ];
+}
+
 
 =head2 pipeline_analyses
 =cut
@@ -348,7 +366,8 @@ sub pipeline_analyses {
                        'max_dropdown' => $self->o('max_dropdown'),
                        'base_name' => $self->o('base_name') },
       -analysis_capacity => 1,
-      -rc_name           => 'mem'
+      -rc_name           => 'mem',
+      -flow_into    => 'run_tests'
     },
     {
       -logic_name      => 'ScheduleSpecies',
@@ -435,6 +454,42 @@ sub pipeline_analyses {
       -analysis_capacity => 10,
       -rc_name           => 'default',
     },
+    { -logic_name  => 'run_tests',
+        -module      => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+        -meadow_type => 'LSF',
+        -flow_into    => 'check_tests',
+        -parameters  => {
+                         'cmd' =>
+                         'cd #test_dir#;perl #base_dir#/ensembl-biomart/scripts/pre_configuration_mart_healthcheck.pl -newuser #user# -newpass #pass# -newport #port# -newhost #host# -olduser #olduser# -oldport #oldport# -oldhost #oldhost# -new_dbname #mart# -old_dbname #old_mart# -old_rel #old_release# -new_rel #new_release# -empty_column 1 -grch37 #grch37#',
+                         'mart'   => $self->o('mart'),
+                         'user'     => $self->o('user'),
+                         'pass'     => $self->o('pass'),
+                         'host'     => $self->o('host'),
+                         'port'     => $self->o('port'),
+                         'olduser'     => $self->o('olduser'),
+                         'oldhost'     => $self->o('oldhost'),
+                         'oldport'     => $self->o('oldport'),
+                         'old_mart'     => $self->o('old_mart'),
+                         'test_dir'    => $self->o('test_dir'),
+                         'old_release' => $self->o('old_release'),
+                         'new_release' => $self->o('new_release'),
+                         'base_dir' => $self->o('base_dir'),
+                         'grch37' => $self->o('grch37') },
+        -analysis_capacity => 1 },
+      { -logic_name  => 'check_tests',
+        -module      => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+        -meadow_type => 'LSF',
+        -max_retry_count   => 0,
+        -parameters  => {
+                         'cmd' =>
+                         'EXIT_CODE=0;failed_tests=`find #test_dir#/#old_mart#_#oldhost#_vs_#mart#_#host#.* -type f ! -empty -print`;if [ -n "$failed_tests" ]; then >&2 echo "Some tests have failed please check ${failed_tests}";EXIT_CODE=1;fi;exit $EXIT_CODE',
+                         'mart'   => $self->o('mart'),
+                         'host'     => $self->o('host'),
+                         'oldhost'     => $self->o('oldhost'),
+                         'old_mart'     => $self->o('old_mart'),
+                         'test_dir'    => $self->o('test_dir'),
+        -analysis_capacity => 1 },
+      }
 
   ];
   return $analyses;


### PR DESCRIPTION
…r the generate_meta step. The pipeline will run the tests and then check that the result files are empty using bash commands.
I tested each pipeline on vert and non-vert and updated the documentation for all the marts: https://www.ebi.ac.uk/seqdb/confluence/display/GTI/BioMart