### PR TITLE
Replaced Blue crowned manakin (lepidothrix_coronata) with Rainbow trout (oncorhynchus_mykiss)

### DIFF
--- a/scripts/include_vertebrates.ini
+++ b/scripts/include_vertebrates.ini
@@ -85,7 +85,7 @@ labrus_bergylta
 lates_calcarifer
 lynx_canadensis
 latimeria_chalumnae
-lepidothrix_coronata
+oncorhynchus_mykiss
 larimichthys_crocea
 lepisosteus_oculatus
 lonchura_striata_domestica


### PR DESCRIPTION
Users have requested that Rainbow trout be added to Biomart so I have replaced Blue crowned manakin.
Marc and Fergal approved the change.