### PR TITLE
Pass 'mart' parameter to testing script

### DIFF
--- a/modules/Bio/EnsEMBL/EGPipeline/PipeConfig/VariationMart_conf.pm
+++ b/modules/Bio/EnsEMBL/EGPipeline/PipeConfig/VariationMart_conf.pm
@@ -557,7 +557,7 @@ sub pipeline_analyses {
       -logic_name  => 'run_tests',
       -module      => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
       -parameters  => {
-                        cmd => 'cd #test_dir#;perl #base_dir#/ensembl-biomart/scripts/pre_configuration_mart_healthcheck.pl -newuser #user# -newpass #pass# -newport #port# -newhost #host# -olduser #olduser# -oldport #oldport# -oldhost #oldhost# -new_dbname #mart# -old_dbname #old_mart# -old_rel #old_release# -new_rel #new_release# -empty_column 1 -grch37 #grch37#',
+                        cmd => 'cd #test_dir#;perl #base_dir#/ensembl-biomart/scripts/pre_configuration_mart_healthcheck.pl -newuser #user# -newpass #pass# -newport #port# -newhost #host# -olduser #olduser# -oldport #oldport# -oldhost #oldhost# -new_dbname #mart# -old_dbname #old_mart# -old_rel #old_release# -new_rel #new_release# -empty_column 1 -grch37 #grch37# -mart snp_mart',
                         mart        => $self->o('mart_db_name'),
                         user        => $self->o('user'),
                         pass        => $self->o('pass'),

--- a/modules/Bio/EnsEMBL/PipeConfig/BuildMart_conf.pm
+++ b/modules/Bio/EnsEMBL/PipeConfig/BuildMart_conf.pm
@@ -307,7 +307,7 @@ sub pipeline_analyses {
       -logic_name => 'run_tests',
       -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
       -parameters => {
-        cmd => 'cd #test_dir#;perl #base_dir#/ensembl-biomart/scripts/pre_configuration_mart_healthcheck.pl -newuser #user# -newpass #pass# -newport #port# -newhost #host# -olduser #olduser# -oldport #oldport# -oldhost #oldhost# -new_dbname #mart# -old_dbname #old_mart# -old_rel #old_release# -new_rel #new_release# -empty_column 1 -grch37 #grch37#',
+        cmd => 'cd #test_dir#;perl #base_dir#/ensembl-biomart/scripts/pre_configuration_mart_healthcheck.pl -newuser #user# -newpass #pass# -newport #port# -newhost #host# -olduser #olduser# -oldport #oldport# -oldhost #oldhost# -new_dbname #mart# -old_dbname #old_mart# -old_rel #old_release# -new_rel #new_release# -empty_column 1 -grch37 #grch37# -mart ensembl_mart',
         oldhost     => $self->o('oldhost'),
         oldport     => $self->o('oldport'),
         olduser     => $self->o('olduser'),

--- a/modules/Bio/EnsEMBL/PipeConfig/BuildRegulationMart_conf.pm
+++ b/modules/Bio/EnsEMBL/PipeConfig/BuildRegulationMart_conf.pm
@@ -354,7 +354,7 @@ sub pipeline_analyses {
         -flow_into    => 'check_tests',
         -parameters  => {
                          'cmd' =>
-                         'cd #test_dir#;perl #base_dir#/scripts/pre_configuration_mart_healthcheck.pl -newuser #user# -newpass #pass# -newport #port# -newhost #host# -olduser #olduser# -oldport #oldport# -oldhost #oldhost# -new_dbname #mart# -old_dbname #old_mart# -old_rel #old_release# -new_rel #new_release# -empty_column 1 -grch37 #grch37#',
+                         'cd #test_dir#;perl #base_dir#/scripts/pre_configuration_mart_healthcheck.pl -newuser #user# -newpass #pass# -newport #port# -newhost #host# -olduser #olduser# -oldport #oldport# -oldhost #oldhost# -new_dbname #mart# -old_dbname #old_mart# -old_rel #old_release# -new_rel #new_release# -empty_column 1 -grch37 #grch37# -mart regulation_mart',
                          'mart'   => $self->o('mart'),
                          'user'     => $self->o('user'),
                          'pass'     => $self->o('pass'),

--- a/modules/Bio/EnsEMBL/PipeConfig/BuildSeqMart_conf.pm
+++ b/modules/Bio/EnsEMBL/PipeConfig/BuildSeqMart_conf.pm
@@ -159,7 +159,7 @@ sub pipeline_analyses {
         -flow_into    => 'check_tests',
         -parameters  => {
                          'cmd' =>
-                         'cd #test_dir#;perl #base_dir#/ensembl-biomart/scripts/pre_configuration_mart_healthcheck.pl -newuser #user# -newpass #pass# -newport #port# -newhost #host# -olduser #olduser# -oldport #oldport# -oldhost #oldhost# -new_dbname #mart# -old_dbname #old_mart# -old_rel #old_release# -new_rel #new_release# -empty_column 1 -grch37 #grch37#',
+                         'cd #test_dir#;perl #base_dir#/ensembl-biomart/scripts/pre_configuration_mart_healthcheck.pl -newuser #user# -newpass #pass# -newport #port# -newhost #host# -olduser #olduser# -oldport #oldport# -oldhost #oldhost# -new_dbname #mart# -old_dbname #old_mart# -old_rel #old_release# -new_rel #new_release# -empty_column 1 -grch37 #grch37# -mart sequence_mart',
                          'mart'   => $self->o('mart'),
                          'user'     => $self->o('user'),
                          'pass'     => $self->o('pass'),


### PR DESCRIPTION
Otherwise it will loop around all the different mart types (of which there are 7), redundantly doing tests (https://github.com/Ensembl/ensembl-biomart/blob/master/scripts/pre_configuration_mart_healthcheck.pl#L88).
Tests can take several hours, so this could shave a day or two off our mart building time.