### PR TITLE
Disable OrderColumns in VariationMart_conf

### DIFF
--- a/modules/Bio/EnsEMBL/EGPipeline/PipeConfig/VariationMart_conf.pm
+++ b/modules/Bio/EnsEMBL/EGPipeline/PipeConfig/VariationMart_conf.pm
@@ -430,7 +430,7 @@ sub pipeline_analyses {
                             },
       -max_retry_count   => 0,
       -analysis_capacity => 10,
-      -flow_into         => ['CreateMartIndexes'],
+      -flow_into         => ['CreateDependentTables'],
     },
 
     # {

--- a/modules/Bio/EnsEMBL/EGPipeline/PipeConfig/VariationMart_conf.pm
+++ b/modules/Bio/EnsEMBL/EGPipeline/PipeConfig/VariationMart_conf.pm
@@ -374,7 +374,7 @@ sub pipeline_analyses {
       -analysis_capacity => 10,
       -flow_into         => {
                               '1->A' => ['PartitionTables'],
-                              'A->1' => ['OrderColumns'],
+                              'A->1' => ['CreateMartIndexes'],
                             },
     },
 
@@ -393,7 +393,7 @@ sub pipeline_analyses {
       -analysis_capacity => 10,
       -flow_into         => {
                               '1->A' => ['PartitionTables'],
-                              'A->1' => ['OrderColumns'],
+                              'A->1' => ['CreateMartIndexes'],
                             },
     },
 
@@ -430,17 +430,17 @@ sub pipeline_analyses {
                             },
       -max_retry_count   => 0,
       -analysis_capacity => 10,
-      -flow_into         => ['CreateDependentTables'],
+      -flow_into         => ['CreateMartIndexes'],
     },
 
-    {
-      -logic_name        => 'OrderColumns',
-      -module            => 'Bio::EnsEMBL::EGPipeline::VariationMart::OrderColumns',
-      -parameters        => {
-                            },
-      -flow_into         => ['CreateMartIndexes'],
-      -max_retry_count   => 3,
-    },
+    # {
+    #   -logic_name        => 'OrderColumns',
+    #   -module            => 'Bio::EnsEMBL::EGPipeline::VariationMart::OrderColumns',
+    #   -parameters        => {
+    #                         },
+    #   -flow_into         => ['CreateMartIndexes'],
+    #   -max_retry_count   => 3,
+    # },
 
     {
       -logic_name        => 'CreateMartIndexes',


### PR DESCRIPTION
Kind of testing if mart building will be faster overall for 103, without ordering by column