### PR TITLE
Use scratch_dir parameter for metadata creation.

### DIFF
--- a/modules/Bio/EnsEMBL/BioMart/MetaBuilder.pm
+++ b/modules/Bio/EnsEMBL/BioMart/MetaBuilder.pm
@@ -107,9 +107,9 @@ sub new {
 =cut
 
 sub build {
-  my ( $self, $template_name, $template, $genomic_features_mart, $ini_file, $registry_loaded ) = @_;
+  my ( $self, $template_name, $template, $genomic_features_mart, $ini_file, $registry_loaded, $scratch_dir ) = @_;
   # create base metatables
-  $self->create_metatables( $template_name, $template );
+  $self->create_metatables( $template_name, $template, $scratch_dir );
   # read datasets
   my $datasets = $self->get_datasets();
   # get latest species_id from the dataset_name table
@@ -1076,7 +1076,7 @@ sub restore_main {
 }
 
 sub create_metatables {
-  my ( $self, $template_name, $template ) = @_;
+  my ( $self, $template_name, $template, $scratch_dir ) = @_;
   $logger->info("Creating meta tables");
 
   # create tables
@@ -1103,10 +1103,11 @@ sub create_metatables {
   my $template_xml =
     XMLout( { DatasetConfig => $template->{config} }, KeepRoot => 1 );
 
-  if ( !-d "./scratch" ) {
-    mkdir "./scratch";
+  $scratch_dir = './scratch' unless defined $scratch_dir;
+  if ( !-d $scratch_dir ) {
+    mkdir $scratch_dir;
   }
-  open my $out, ">", "./scratch/tmp.xml";
+  open my $out, ">", "$scratch_dir/tmp.xml";
   print $out $template_xml;
   close $out;
   my $gzip_template;

--- a/modules/Bio/EnsEMBL/PipeConfig/BuildMart_conf.pm
+++ b/modules/Bio/EnsEMBL/PipeConfig/BuildMart_conf.pm
@@ -265,11 +265,12 @@ sub pipeline_analyses {
             -logic_name => 'generate_meta',
             -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
             -parameters => {
-                cmd                   => 'perl #base_dir#/ensembl-biomart/scripts/generate_meta.pl -user #user# -pass #pass# -port #port# -host #host# -dbname #mart# -template #template# -ds_basename #base_name# -template_name #template_name# -genomic_features_dbname #genomic_features_mart# -max_dropdown #max_dropdown#',
+                cmd                   => 'perl #base_dir#/ensembl-biomart/scripts/generate_meta.pl -user #user# -pass #pass# -port #port# -host #host# -dbname #mart# -template #template# -ds_basename #base_name# -template_name #template_name# -genomic_features_dbname #genomic_features_mart# -max_dropdown #max_dropdown# -scratch_dir #scratch_dir#',
                 template              => $self->o('template'),
                 template_name         => $self->o('template_name'),
                 max_dropdown          => $self->o('max_dropdown'),
                 genomic_features_mart => $self->o('genomic_features_mart'),
+                scratch_dir           => $self->o('scratch_dir'),
             },
             -rc_name    => 'low',
             -flow_into  => [ 'run_tests' ],

--- a/modules/Bio/EnsEMBL/PipeConfig/BuildRegulationMart_conf.pm
+++ b/modules/Bio/EnsEMBL/PipeConfig/BuildRegulationMart_conf.pm
@@ -191,7 +191,7 @@ sub pipeline_analyses {
             -meadow_type       => 'LSF',
             -parameters        => {
                 'cmd'                   =>
-                    'perl #base_dir#/scripts/generate_meta.pl -user #user# -pass #pass# -port #port# -host #host# -dbname #mart# -template #template# -ds_basename #base_name# -template_name #template_name# -genomic_features_dbname #genomic_features_mart# -max_dropdown #max_dropdown#',
+                    'perl #base_dir#/scripts/generate_meta.pl -user #user# -pass #pass# -port #port# -host #host# -dbname #mart# -template #template# -ds_basename #base_name# -template_name #template_name# -genomic_features_dbname #genomic_features_mart# -max_dropdown #max_dropdown# -scratch_dir #scratch_dir#',
                 'mart'                  => $self->o('mart'),
                 'template'              => $self->o('base_dir') . '/scripts/templates/external_feature_template_template.xml',
                 'user'                  => $self->o('user'),
@@ -202,7 +202,8 @@ sub pipeline_analyses {
                 'template_name'         => 'external_features',
                 'genomic_features_mart' => $self->o('genomic_features_mart'),
                 'max_dropdown'          => $self->o('max_dropdown'),
-                'base_name'             => 'external_feature'
+                'base_name'             => 'external_feature',
+                'scratch_dir'           => $self->o('scratch_dir'),
             },
             -analysis_capacity => 1,
             -flow_into         => [ 'generate_meta_peaks' ],
@@ -213,7 +214,7 @@ sub pipeline_analyses {
             -meadow_type       => 'LSF',
             -parameters        => {
                 'cmd'                   =>
-                    'perl #base_dir#/scripts/generate_meta.pl -user #user# -pass #pass# -port #port# -host #host# -dbname #mart# -template #template# -ds_basename #base_name# -template_name #template_name# -genomic_features_dbname #genomic_features_mart# -max_dropdown #max_dropdown#',
+                    'perl #base_dir#/scripts/generate_meta.pl -user #user# -pass #pass# -port #port# -host #host# -dbname #mart# -template #template# -ds_basename #base_name# -template_name #template_name# -genomic_features_dbname #genomic_features_mart# -max_dropdown #max_dropdown# -scratch_dir #scratch_dir#',
                 'mart'                  => $self->o('mart'),
                 'template'              => $self->o('base_dir') . '/scripts/templates/peak_template_template.xml',
                 'user'                  => $self->o('user'),
@@ -224,7 +225,8 @@ sub pipeline_analyses {
                 'template_name'         => 'peaks',
                 'genomic_features_mart' => $self->o('genomic_features_mart'),
                 'max_dropdown'          => $self->o('max_dropdown'),
-                'base_name'             => 'peak'
+                'base_name'             => 'peak',
+                'scratch_dir'           => $self->o('scratch_dir'),
             },
             -analysis_capacity => 1,
             -flow_into         => [ 'generate_meta_regulatory_features' ]
@@ -235,7 +237,7 @@ sub pipeline_analyses {
             -meadow_type       => 'LSF',
             -parameters        => {
                 'cmd'                   =>
-                    'perl #base_dir#/scripts/generate_meta.pl -user #user# -pass #pass# -port #port# -host #host# -dbname #mart# -template #template# -ds_basename #base_name# -template_name #template_name# -genomic_features_dbname #genomic_features_mart# -max_dropdown #max_dropdown#',
+                    'perl #base_dir#/scripts/generate_meta.pl -user #user# -pass #pass# -port #port# -host #host# -dbname #mart# -template #template# -ds_basename #base_name# -template_name #template_name# -genomic_features_dbname #genomic_features_mart# -max_dropdown #max_dropdown# -scratch_dir #scratch_dir#',
                 'mart'                  => $self->o('mart'),
                 'template'              => $self->o('base_dir') . '/scripts/templates/regulatory_feature_template_template.xml',
                 'user'                  => $self->o('user'),
@@ -246,7 +248,8 @@ sub pipeline_analyses {
                 'template_name'         => 'regulatory_features',
                 'genomic_features_mart' => $self->o('genomic_features_mart'),
                 'max_dropdown'          => $self->o('max_dropdown'),
-                'base_name'             => 'regulatory_feature'
+                'base_name'             => 'regulatory_feature',
+                'scratch_dir'           => $self->o('scratch_dir'),
             },
             -analysis_capacity => 1,
             -flow_into         => 'run_tests',

--- a/modules/Bio/EnsEMBL/PipeConfig/BuildSeqMart_conf.pm
+++ b/modules/Bio/EnsEMBL/PipeConfig/BuildSeqMart_conf.pm
@@ -123,13 +123,14 @@ sub pipeline_analyses {
             -flow_into         => 'run_tests',
             -parameters        => {
                 'cmd'      =>
-                    'perl #base_dir#/ensembl-biomart/scripts/generate_meta.pl -user #user# -pass #pass# -port #port# -host #host# -dbname #mart# -template #base_dir#/ensembl-biomart/scripts/templates/sequence_template_template.xml  -ds_basename genomic_sequence -template_name sequences',
+                    'perl #base_dir#/ensembl-biomart/scripts/generate_meta.pl -user #user# -pass #pass# -port #port# -host #host# -dbname #mart# -template #base_dir#/ensembl-biomart/scripts/templates/sequence_template_template.xml  -ds_basename genomic_sequence -template_name sequences -scratch_dir #scratch_dir#',
                 'mart'     => $self->o('mart'),
                 'user'     => $self->o('user'),
                 'pass'     => $self->o('pass'),
                 'host'     => $self->o('host'),
                 'port'     => $self->o('port'),
-                'base_dir' => $self->o('base_dir')
+                'base_dir' => $self->o('base_dir'),
+                'scratch_dir' => $self->o('scratch_dir'),
             },
             -analysis_capacity => 1 },
         {

--- a/modules/Bio/EnsEMBL/PipeConfig/GenericMart_conf.pm
+++ b/modules/Bio/EnsEMBL/PipeConfig/GenericMart_conf.pm
@@ -53,7 +53,7 @@ sub default_options {
         'division'    => '',
         'mart_dir'    => getcwd,
         'scratch_dir' => catdir('/hps/scratch', $self->o('env_user'), $self->o('pipeline_name')),
-        'test_dir'    => catdir('/hps/nobackup/flicek/ensembl/production', $self->o('user'),
+        'test_dir'    => catdir('/hps/nobackup/flicek/ensembl/production', $self->o('env_user'),
             'mart_test', $self->o('pipeline_name')),
     }
 }

--- a/scripts/generate_meta.pl
+++ b/scripts/generate_meta.pl
@@ -89,6 +89,7 @@ push( @{$optsd}, "genomic_features_dbname:s" );
 push( @{$optsd}, "registry:s" );
 push( @{$optsd}, "xref_url_ini_file:s");
 push( @{$optsd}, "max_dropdown:i" );
+push( @{$optsd}, "scratch_dir:s" );
 push( @{$optsd}, "verbose" );
 
 # process the command line with the supplied options plus a help subroutine
@@ -149,5 +150,5 @@ my $builder =
                                            -BASENAME => $opts->{ds_basename},
                                            -MAX_DROPDOWN =>  $opts->{max_dropdown} );
 
-$builder->build( $opts->{template_name}, $templ, $opts->{genomic_features_dbname}, $opts->{ini_file}, $registry_loaded );
+$builder->build( $opts->{template_name}, $templ, $opts->{genomic_features_dbname}, $opts->{ini_file}, $registry_loaded, $opts->{scratch_dir} );
 


### PR DESCRIPTION
The scratch directory path was hard-coded as './scratch'. We want to use the pipeline value, which will default to /hps/scratch/$USER/<pipeline_name> on Codon.

Also changed the test directory dumps to match the environment user - that's consistent with everything else, and probably best not to rely on the RW database user being called 'ensprod'.