### PR TITLE
Fix default scratch_dir for GenericMart_conf and CreateMTMPTables

### DIFF
--- a/modules/Bio/EnsEMBL/PipeConfig/GenericMart_conf.pm
+++ b/modules/Bio/EnsEMBL/PipeConfig/GenericMart_conf.pm
@@ -52,7 +52,7 @@ sub default_options {
         'antispecies' => [],
         'division'    => '',
         'mart_dir'    => getcwd,
-        'scratch_dir' => catdir('/hps/scratch', $self->o('env_user'), $self->o('pipeline_name')),
+        'scratch_dir' => catdir('/hps/scratch/flicek/ensembl', $self->o('env_user'), $self->o('pipeline_name')),
         'test_dir'    => catdir('/hps/nobackup/flicek/ensembl/production', $self->o('env_user'),
             'mart_test', $self->o('pipeline_name')),
     }

--- a/modules/Bio/EnsEMBL/VariationMart/CreateMTMPTables.pm
+++ b/modules/Bio/EnsEMBL/VariationMart/CreateMTMPTables.pm
@@ -32,7 +32,7 @@ sub param_defaults {
     'motif_exits'       => 1,
     'show_sams'         => 1,
     'show_pops'         => 1,
-    'scratch_dir'           => '/scratch',
+    'scratch_dir'       => '/hps/scratch/flicek/ensembl',
   };
 }
 
@@ -83,7 +83,7 @@ sub sample_genotype {
   my $drop_mtmp = $self->param_required('drop_mtmp');
   my $dbc = $self->get_DBAdaptor('variation')->dbc();
   my $scratch_dir = $self->param_required('scratch_dir');
-  my $output_file = "$scratch_dir/mtmp_sg_".$self->param_required('species').".txt";
+  my $output_file = "$scratch_dir/".$self->o('ENV', 'USER')."/mtmp_sg_".$self->param_required('species').".txt";
   
   my $hive_dbc = $self->dbc;
   $hive_dbc->disconnect_if_idle();


### PR DESCRIPTION
Set default scratch_dir root to /hps/scratch/flicek/ensembl