### PR TITLE
Bugfixes/column duplicate

### DIFF
--- a/modules/Bio/EnsEMBL/BioMart/ConcatColumns.pm
+++ b/modules/Bio/EnsEMBL/BioMart/ConcatColumns.pm
@@ -54,7 +54,8 @@ sub create_stable_id_version_column {
       my $column1_types = $mart_dbc->sql_helper->execute_simple(-SQL=>"SELECT COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = '$mart_table' AND COLUMN_NAME = '$column1';"); 
       my $column1_type = $column1_types->[0];
       # Create new column
-      $mart_dbc->sql_helper->execute_update(-SQL=>"ALTER TABLE $mart_table ADD COLUMN ${table}_stable_id_version $column1_type;");
+      # WAS $mart_dbc->sql_helper->execute_update(-SQL=>"ALTER TABLE $mart_table ADD COLUMN ${table}_stable_id_version $column1_type;");
+      $self->add_column($mart_table, $table.'_stable_id_version', $column1_type);
       # Concat table
       $mart_dbc->sql_helper->execute_update(-SQL=>"UPDATE $mart_table SET ${table}_stable_id_version = CONCAT($column1, '$concat_separator', $column2);");
       # Create index
@@ -95,7 +96,8 @@ sub replicate_column_child_tables {
   #Drop column if exist
   $self->drop_column_if_exist($mart_dbc,$child_mart_table,$column);
   # Create new column
-  $mart_dbc->sql_helper->execute_update(-SQL=>"ALTER TABLE $child_mart_table ADD COLUMN $column $column_type;");
+  # WAS $mart_dbc->sql_helper->execute_update(-SQL=>"ALTER TABLE $child_mart_table ADD COLUMN $column $column_type;");
+  $self->add_column($child_mart_table, $column, $column_type);
   # Concat table
   $mart_dbc->sql_helper->execute_update(-SQL=>"UPDATE $child_mart_table INNER JOIN $mart_table ON $mart_table.$main_table_key = $child_mart_table.$main_table_key SET $child_mart_table.$column = CONCAT($mart_table.$column1, '$concat_separator', $mart_table.$column2);");
   # Create index

--- a/modules/Bio/EnsEMBL/VariationMart/AggregatedData.pm
+++ b/modules/Bio/EnsEMBL/VariationMart/AggregatedData.pm
@@ -93,11 +93,8 @@ sub variation_annotation_bool {
   my ($self, $mart_table_prefix, $variation_db, $prefix) = @_;
   my $hive_dbc = $self->dbc;
   $hive_dbc->disconnect_if_idle();
-  
-  my $table_sql =
-    'ALTER TABLE '.$mart_table_prefix.'_snp'.$prefix.'__variation__main '.
-    'ADD COLUMN variation_annotation_bool int(11) DEFAULT 0';
-  
+  $self->add_column($mart_table_prefix.'_snp'.$prefix.'__variation__main', 'variation_annotation_bool', 'int(11) DEFAULT 0');
+
   my $update_sql =
     'UPDATE '.
     $mart_table_prefix.'_snp'.$prefix.'__variation__main v_m INNER JOIN '.
@@ -110,7 +107,6 @@ sub variation_annotation_bool {
     '(variation_annotation_bool);';
   
   my $mart_dbc = $self->mart_dbc;
-  $mart_dbc->sql_helper->execute_update(-SQL=>$table_sql) or $self->throw($mart_dbc->errstr);
   $mart_dbc->sql_helper->execute_update(-SQL=>$update_sql) or $self->throw($mart_dbc->errstr);
   $mart_dbc->sql_helper->execute_update(-SQL=>$index_sql) or $self->throw($mart_dbc->errstr);
   $mart_dbc->disconnect_if_idle();

--- a/modules/Bio/EnsEMBL/VariationMart/Base.pm
+++ b/modules/Bio/EnsEMBL/VariationMart/Base.pm
@@ -72,6 +72,24 @@ sub does_table_exist {
   return $exists;
 }
 
+sub does_column_exist{
+  my ($self, $table_name, $column_name) = @_;
+  my $check_sql = "SHOW COLUMNS FROM `$table_name` LIKE '$column_name'";
+  my $mart_dbc = $self->mart_dbc;
+  my ($res) = $mart_dbc->sql_helper->execute_simple(-SQL=>$check_sql)->[0];
+  return $res ? 1 : 0;
+}
+
+sub add_column{
+  my ($self, $table_name, $column_name, $col_def) = @_;
+  if (! $self->does_column_exist($table_name, $column_name)) {
+    my $sql_column = 'ALTER TABLE '.$table_name.' ADD COLUMN '.$column_name.' '.$col_def;
+    my $mart_dbc = $self->mart_dbc;
+    $mart_dbc->sql_helper->execute_update(-SQL=>$sql_column) or $self->throw($mart_dbc->errstr);
+    $mart_dbc->disconnect_if_idle();
+  }
+}
+
 sub order_consequences {
   my ($self) = @_;
   my $hive_dbc = $self->dbc;

--- a/modules/t/10-iterate.t
+++ b/modules/t/10-iterate.t
@@ -20,7 +20,7 @@ use Bio::EnsEMBL::BioMart::MartService;
 use Data::Dumper;
 
 my $srv = Bio::EnsEMBL::BioMart::MartService->new(
-    -URL => 'http://fungi.ensembl.org/biomart/martservice');
+    -URL => 'https://fungi.ensembl.org/biomart/martservice');
 
 my @marts = @{$srv->get_marts()};
 ok(scalar(@marts) == 4);

--- a/modules/t/20-query-bool.t
+++ b/modules/t/20-query-bool.t
@@ -20,7 +20,7 @@ use Bio::EnsEMBL::BioMart::MartService;
 use Data::Dumper;
 
 my $srv = Bio::EnsEMBL::BioMart::MartService->new(
-					   -URL => 'http://fungi.ensembl.org/biomart/martservice' );
+					   -URL => 'https://fungi.ensembl.org/biomart/martservice' );
 ok( defined $srv, "Service found" );
 
 my $mart;

--- a/modules/t/21-query-val.t
+++ b/modules/t/21-query-val.t
@@ -20,7 +20,7 @@ use Bio::EnsEMBL::BioMart::MartService;
 use Data::Dumper;
 
 my $srv = Bio::EnsEMBL::BioMart::MartService->new(
-					   -URL => 'http://fungi.ensembl.org/biomart/martservice' );
+					   -URL => 'https://fungi.ensembl.org/biomart/martservice' );
 ok( defined $srv, "Service found" );
 
 my $mart;


### PR DESCRIPTION
To remove this annoying error message we got when building Variation Mart (and other potential occurrence at the same time!):
`MSG: Cannot apply sql 'ALTER TABLE sscrofa_structvar__structural_variation__main ADD COLUMN structural_variation_feature_count int(11) DEFAULT 0' with params '': DBD::mysql::st execute failed: Duplicate column name 'structural_variation_feature_count' at /hps/software/users/ensembl/repositories/enseven/ensembl/modules/Bio/EnsEMBL/Utils/SqlHelper.pm line 722. STACK Bio::EnsEMBL::Utils::SqlHelper::execute_update /hps/software/users/ensembl/repositories/enseven/ensembl/modules/Bio/EnsEMBL/Utils/SqlHelper.pm:729 STACK `