### PR TITLE
Bug fix indexname too long

### DIFF
--- a/modules/Bio/EnsEMBL/BioMart/ConcatColumns.pm
+++ b/modules/Bio/EnsEMBL/BioMart/ConcatColumns.pm
@@ -59,7 +59,7 @@ sub create_stable_id_version_column {
       # Concat table
       $mart_dbc->sql_helper->execute_update(-SQL => "UPDATE $mart_table SET ${table}_stable_id_version = CONCAT($column1, '$concat_separator', $column2);");
       # Create index
-      $self->add_index($mart_table, $mart_table.'_'.${table}.'_stable_id_version', "(${table}_stable_id_version)");
+      $self->add_index($mart_table, ${table}.'_stable_id_version', "(${table}_stable_id_version)");
       # WAS $mart_dbc->sql_helper->execute_update(-SQL=>"ALTER TABLE $mart_table ADD INDEX (${table}_stable_id_version);");
       # Replicate column in child tables.
       # E.g: from Gene main table to Transcript and Translation


### PR DESCRIPTION
Fix index name too long
```
-------------------- EXCEPTION --------------------
MSG: Cannot apply sql 'CREATE INDEX `abrachyrhynchus_gene_ensembl__gene__main_gene__main_stable_id_version` ON abrachyrhynchus_gene_ensembl__gene__main (gene__main_stable_id_version)' with params '': DBD::mysql::st execute failed: Identifier name 'abrachyrhynchus_gene_ensembl__gene__main_gene__main_stable_id_version' is too long at /hps/software/users/ensembl/repositories/ensodd/ensembl/modules/Bio/EnsEMBL/Utils/SqlHelper.pm line 722.

STACK Bio::EnsEMBL::Utils::SqlHelper::execute_update /hps/software/users/ensembl/repositories/ensodd/ensembl/modules/Bio/EnsEMBL/Utils/SqlHelper.pm:729
STACK Bio::EnsEMBL::VariationMart::Base::add_index /hps/software/users/ensembl/repositories/ensodd/ensembl-biomart/modules/Bio/EnsEMBL/VariationMart/Base.pm:106
STACK Bio::EnsEMBL::BioMart::ConcatColumns::create_stable_id_version_column /hps/software/users/ensembl/repositories/ensodd/ensembl-biomart/modules/Bio/EnsEMBL/BioMart/ConcatColumns.pm:62
STACK Bio::EnsEMBL::BioMart::ConcatColumns::run /hps/software/users/ensembl/repositories/ensodd/ensembl-biomart/modules/Bio/EnsEMBL/BioMart/ConcatColumns.pm:32
STACK (eval) /hps/software/users/ensembl/repositories/ensodd/ensembl-hive/modules/Bio/EnsEMBL/Hive/Process.pm:150
STACK Bio::EnsEMBL::Hive::Process::life_cycle /hps/software/users/ensembl/repositories/ensodd/ensembl-hive/modules/Bio/EnsEMBL/Hive/Process.pm:132
STACK (eval) /hps/software/users/ensembl/repositories/ensodd/ensembl-hive/modules/Bio/EnsEMBL/Hive/Worker.pm:754
STACK Bio::EnsEMBL::Hive::Worker::run_one_batch /hps/software/users/ensembl/repositories/ensodd/ensembl-hive/modules/Bio/EnsEMBL/Hive/Worker.pm:742
STACK Bio::EnsEMBL::Hive::Worker::run /hps/software/users/ensembl/repositories/ensodd/ensembl-hive/modules/Bio/EnsEMBL/Hive/Worker.pm:575
STACK (eval) /hps/software/users/ensembl/repositories/ensodd/ensembl-hive/modules/Bio/EnsEMBL/Hive/Scripts/RunWorker.pm:76
STACK Bio::EnsEMBL::Hive::Scripts::RunWorker::runWorker /hps/software/users/ensembl/repositories/ensodd/ensembl-hive/modules/Bio/EnsEMBL/Hive/Scripts/RunWorker.pm:86
STACK main::main /hps/software/users/ensembl/repositories/ensodd/ensembl-hive/scripts/runWorker.pl:153
STACK toplevel /hps/software/users/ensembl/repositories/ensodd/ensembl-hive/scripts/runWorker.pl:24
Date (localtime)    = Fri May 20 11:10:11 2022
Ensembl API version = 107
```