### PR TITLE
Get Vertebrates BioMart species from dedicated file

### DIFF
--- a/modules/Bio/EnsEMBL/BioMart/Mart.pm
+++ b/modules/Bio/EnsEMBL/BioMart/Mart.pm
@@ -87,10 +87,10 @@ sub genome_to_include {
     my $filename;
     my $included_species;
     if (defined $base_dir) {
-        $filename = $base_dir . '/ensembl-compara/conf/' . $division . '/allowed_species.json';
+        $filename = $base_dir . '/ensembl-compara/conf/' . $division . '/biomart_species.json';
     }
     else {
-        $filename = $FindBin::Bin . '/../ensembl-compara/conf/' . $division . '/allowed_species.json';
+        $filename = $FindBin::Bin . '/../ensembl-compara/conf/' . $division . '/biomart_species.json';
     }
     my $filecontent = read_file($filename);
     # print Dumper($filecontent);

--- a/modules/t/11-config.t
+++ b/modules/t/11-config.t
@@ -21,7 +21,7 @@ use File::Slurp;
 
 use Bio::EnsEMBL::BioMart::Mart qw(genome_to_include);
 
-my @divisions = ('vertebrates', 'metazoa', 'plants');
+my @divisions = ('vertebrates');
 
 for my $division (@divisions) {
     my $species = genome_to_include($division,  $ENV{'BASE_DIR'});


### PR DESCRIPTION
## Description

A dedicated `biomart_species.json` has been added to the Vertebrates Compara species config in [Compara PR #583](https://github.com/Ensembl/ensembl-compara/pull/583).

This PR effectively configures the BioMart species list to be taken from the new `biomart_species.json` file instead of the Vertebrates `allowed_species.json` file.

On the assumption that the BioMart `genome_to_include` function is currently used only for Vertebrates, the associated unit test `11-config.t` is restricted to test this function only for Vertebrates.

## Benefits

Having the Vertebrates BioMart `biomart_species.json` file alongside the Vertebrates Compara `allowed_species.json` file will allow the Vertebrates Compara species to differ from the Vertebrates BioMart species, while still maintaining an automatic consistency check.

## Possible Drawbacks

None expected.
