### PR TITLE
Add support for Metazoa BioMart species list

### DIFF
--- a/modules/Bio/EnsEMBL/BioMart/CheckExcludedSpecies.pm
+++ b/modules/Bio/EnsEMBL/BioMart/CheckExcludedSpecies.pm
@@ -35,7 +35,7 @@ sub run {
   my $mca = $dba->get_adaptor('MetaContainer');
   my $division = $mca->get_division;
 
-  if ($division =~ /vertebrates/i) {
+  if ($division =~ /vertebrates|metazoa/i) {
     $included_species = genome_to_include($division, $base_dir);
     if (!grep( /$species/, @$included_species) ){
       $self->complete_early("Excluding $species from mart");

--- a/modules/Bio/EnsEMBL/BioMart/SequenceDatasetFactory.pm
+++ b/modules/Bio/EnsEMBL/BioMart/SequenceDatasetFactory.pm
@@ -64,7 +64,10 @@ create table if not exists $mart.dataset_names (
     my $included_species;
     if ($division eq 'EnsemblProtists') {$pId = 10000;}
     elsif ($division eq 'EnsemblPlants') {$pId = 20000;}
-    elsif ($division eq 'EnsemblMetazoa') {$pId = 30000;}
+    elsif ($division eq 'EnsemblMetazoa') {
+        $pId = 30000;
+        $included_species = genome_to_include($division, $self->param('base_dir'));
+    }
     elsif ($division eq 'EnsemblFungi') {$pId = 40000;}
     elsif ($division eq 'Vectorbase') {$pId = 50000;}
     elsif ($division eq 'Parasite') {$pId = 60000}
@@ -84,7 +87,7 @@ create table if not exists $mart.dataset_names (
 
         my $database = $dba->dbc()->dbname();
         # Excluding species from the sequence mart for vertebrates
-        if ($division eq 'EnsemblVertebrates') {
+        if ($division eq 'EnsemblVertebrates' || $division eq 'EnsemblMetazoa') {
             my $production_name = $dba->get_MetaContainer()->get_production_name();
             # In the vertebrates sequence mart we want to include the mouse strains for the mouse mart
             if (!grep(/$production_name/, @$included_species) and $production_name !~ m/^mus_musculus_/) {

--- a/modules/Bio/EnsEMBL/VariationMart/CopyOrGenerate.pm
+++ b/modules/Bio/EnsEMBL/VariationMart/CopyOrGenerate.pm
@@ -50,7 +50,7 @@ sub write_output {
   my $mart_table_prefix;
   my $included_species;
   # Use division to find the release in metadata database
-  if ($division_name eq "vertebrates"){
+  if ($division_name eq "vertebrates" || $division_name eq "metazoa"){
     # Load species to exclude from the Vertebrates marts
     $included_species = genome_to_include($division_name,$ensembl_cvs_root_dir);
     if (!grep( /$species/, @$included_species) ){

--- a/modules/t/11-config.t
+++ b/modules/t/11-config.t
@@ -21,7 +21,7 @@ use File::Slurp;
 
 use Bio::EnsEMBL::BioMart::Mart qw(genome_to_include);
 
-my @divisions = ('vertebrates');
+my @divisions = ('vertebrates', 'metazoa');
 
 for my $division (@divisions) {
     my $species = genome_to_include($division,  $ENV{'BASE_DIR'});

--- a/scripts/create_martbuilder_file.pl
+++ b/scripts/create_martbuilder_file.pl
@@ -162,6 +162,9 @@ sub get_list {
     }
     else {
         $release = $rdba->fetch_by_ensembl_genomes_release($opts->{eg});
+        if ($opts->{division} eq "EnsemblMetazoa") {
+            $included_species = genome_to_include($opts->{division}, $ENV{BASE_DIR});
+        }
     }
     $gdba->data_release($release);
     # Get all the genomes for a given division and release

--- a/scripts/pre_configuration_mart_healthcheck.pl
+++ b/scripts/pre_configuration_mart_healthcheck.pl
@@ -94,7 +94,7 @@ if ( !defined($division) ) {
   }
 }
 
-if ($division eq "vertebrates") {
+if ($division eq "vertebrates" || $division eq "metazoa") {
   #Get both division short and full name from a division short or full name
   my ($_division, $division_name) = process_division_names($division);
   # Load species to include in the Vertebrates marts


### PR DESCRIPTION
## Description

With the anticipated introduction of a BioMart species list for Metazoa in e112, Ensembl BioMart code which previously applied only to the Vertebrates division needs to be revised to apply also to the Metazoa division.

**Related JIRA tickets:**
- [ENSINT-1549](https://www.ebi.ac.uk/panda/jira/browse/ENSINT-1549)

## Overview of changes

In parts of BioMart code which are currently used to filter Vertebrates species, changes have been made to apply an equivalent filter to Metazoa species.

## Testing

Relevant unit test `11-config.t` passed locally.
