### PR TITLE
Swapped function call for regex

### DIFF
--- a/modules/Bio/EnsEMBL/BioMart/MetaBuilder.pm
+++ b/modules/Bio/EnsEMBL/BioMart/MetaBuilder.pm
@@ -1282,7 +1282,7 @@ sub generate_chromosome_bands_push_action {
             -CALLBACK => sub {
               my ( $row, $value ) = @_;
               $value = [] if !defined $value;
-              push($value, $row->[1] );
+              push(@$value, $row->[1] );
               return $value;
               }
           );
@@ -1291,7 +1291,7 @@ sub generate_chromosome_bands_push_action {
             -CALLBACK => sub {
               my ( $row, $value ) = @_;
               $value = [] if !defined $value;
-              push($value, $row->[1] );
+              push(@$value, $row->[1] );
               return $value;
               }
           );
@@ -1330,7 +1330,7 @@ sub generate_chromosome_qtl_push_action {
             -CALLBACK => sub {
               my ( $row, $value ) = @_;
               $value = [] if !defined $value;
-              push($value, $row->[1] );
+              push(@$value, $row->[1] );
               return $value;
               }
           );

--- a/scripts/calculate_sequence_data.pl
+++ b/scripts/calculate_sequence_data.pl
@@ -122,7 +122,7 @@ for my $dataset (@datasets) {
               -CALLBACK => sub {
               my ( $row, $value ) = @_;
               $value = [] if !defined $value;
-              push($value, $row->[1] );
+              push(@$value, $row->[1] );
               return $value;
               }
             );

--- a/scripts/create_martbuilder_file.pl
+++ b/scripts/create_martbuilder_file.pl
@@ -72,11 +72,11 @@ if (defined $opts->{grch37}) {
         -db_version => $opts->{ens});
 
     my $core_dba = Bio::EnsEMBL::Registry->get_DBAdaptor('homo_sapiens', 'core');
-    push $core, $core_dba->dbc()->dbname();
+    push @$core, $core_dba->dbc()->dbname();
     my $variarion_dba = Bio::EnsEMBL::Registry->get_DBAdaptor('homo_sapiens', 'variation');
-    push $variation, $variarion_dba->dbc()->dbname();
+    push @$variation, $variarion_dba->dbc()->dbname();
     my $regulation_dba = Bio::EnsEMBL::Registry->get_DBAdaptor('homo_sapiens', 'funcgen');
-    push $funcgen, $regulation_dba->dbc()->dbname();
+    push @$funcgen, $regulation_dba->dbc()->dbname();
     $core_dba->dbc()->disconnect_if_idle();
     $variarion_dba->dbc()->disconnect_if_idle();
     $regulation_dba->dbc()->disconnect_if_idle();

--- a/scripts/generate_names.pl
+++ b/scripts/generate_names.pl
@@ -277,7 +277,7 @@ foreach my $dataset (@datasets) {
 "select meta_key,meta_value from meta where species_id='$species_id'" );
 
     if ( !defined $species_names{'species.proteome_id'} ||
-         !isdigit $species_names{'species.proteome_id'} )
+         $species_names{'species.proteome_id'} !~ /^\d+$/ )
     {
       $species_names{'species.proteome_id'} = ++$pId;
     }


### PR DESCRIPTION
Function call needed specific declaration and just did /^\d+$/. Recent versions of perl do not have it intrinsicly.