### PR TITLE
Modified 'GENCODE basic annotation' and 'GENCODE primary annotation' flags

### DIFF
--- a/scripts/templates/gene_template_template.xml
+++ b/scripts/templates/gene_template_template.xml
@@ -198,14 +198,14 @@
           <Option displayName="Excluded" internalName="excluded" useDefault="true" value="excluded"/>
         </FilterDescription>
       </FilterCollection>
-      <FilterCollection displayName="GENCODE basic annotation" internalName="transcript_gencode_basic" useDefault="true">
-        <FilterDescription displayName="GENCODE basic annotation" displayType="list" field="value_1065" internalName="transcript_gencode_basic" key="transcript_id_1064_key" legal_qualifiers="only,excluded" otherFilters="MULTI" qualifier="only" style="radio" tableConstraint="tra_gencode_basic__dm" type="boolean" useDefault="true">
+      <FilterCollection displayName="GENCODE basic" internalName="transcript_gencode_basic" useDefault="true">
+        <FilterDescription displayName="GENCODE basic" displayType="list" field="value_1065" internalName="transcript_gencode_basic" key="transcript_id_1064_key" legal_qualifiers="only,excluded" otherFilters="MULTI" qualifier="only" style="radio" tableConstraint="tra_gencode_basic__dm" type="boolean" useDefault="true">
           <Option displayName="Only" internalName="only" useDefault="true" value="only"/>
           <Option displayName="Excluded" internalName="excluded" useDefault="true" value="excluded"/>
         </FilterDescription>
       </FilterCollection>
-      <FilterCollection displayName="GENCODE primary annotation" internalName="transcript_gencode_primary" useDefault="true">
-        <FilterDescription displayName="GENCODE basic annotation" displayType="list" field="value_1065" internalName="transcript_gencode_primary" key="transcript_id_1064_key" legal_qualifiers="only,excluded" otherFilters="MULTI" qualifier="only" style="radio" tableConstraint="tra_gencode_primary__dm" type="boolean" useDefault="true">
+      <FilterCollection displayName="GENCODE primary" internalName="transcript_gencode_primary" useDefault="true">
+        <FilterDescription displayName="GENCODE primary" displayType="list" field="value_1065" internalName="transcript_gencode_primary" key="transcript_id_1064_key" legal_qualifiers="only,excluded" otherFilters="MULTI" qualifier="only" style="radio" tableConstraint="tra_gencode_primary__dm" type="boolean" useDefault="true">
           <Option displayName="Only" internalName="only" useDefault="true" value="only"/>
           <Option displayName="Excluded" internalName="excluded" useDefault="true" value="excluded"/>
         </FilterDescription>


### PR DESCRIPTION
Removed 'annotation' from the 'GENCODE basic annotation' and 'GENCODE primary annotation' filter display names